### PR TITLE
FIX: Use gdsfactory with pydantic v2

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,7 @@ classifiers = [
   "Operating System :: OS Independent"
 ]
 dependencies = [
-  "gdsfactory[cad]==7.3.0",
+  "gdsfactory[cad]>7.3.0",
   "PySpice"
 ]
 description = "skywater130 pdk"


### PR DESCRIPTION
Hi Joaquin,

I was installing this with pydantic v2 as I was upgrading to the latest gdsfactory and ran into this dependency issue. I think it just needed to use a gdsfactory version with pydantic v2 so `gdsfactory>7.3.0` and it's running fine for me now.

Cheers,
Dario