### PR TITLE
Use tilde requirement for gdsfactory

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,7 @@ classifiers = [
   "Operating System :: OS Independent"
 ]
 dependencies = [
-  "gdsfactory==7.26.0",
+  "gdsfactory~=7.26.0",
   "PySpice"
 ]
 description = "skywater130 pdk"


### PR DESCRIPTION
Right now the requirement specification for gdsfactory is too strict, making it hard to install this pdk alongside others, for example. Using a tilde operator will relax the requirement