### PR TITLE
:wrench: Patch for gplugins r2ladder example

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,8 +15,7 @@ classifiers = [
   "Operating System :: OS Independent"
 ]
 dependencies = [
-  "gdsfactory~=7.26.1",
-  "PySpice"
+  "gdsfactory>=7.26.0,<8"
 ]
 description = "skywater130 pdk"
 keywords = ["python"]

--- a/sky130/layers.py
+++ b/sky130/layers.py
@@ -486,6 +486,7 @@ class LayerMap(BaseModel):
     TM: Layer = (204, 0)
     TEXT: Layer = (66, 0)
     WG: Layer = (203, 0)  # TODO remove when updating gdsfactory7
+    HACK_TODO_REMOVE: Layer = (2, 0)
 
     class Config:
         frozen = True

--- a/sky130/pcells/p_n_poly.py
+++ b/sky130/pcells/p_n_poly.py
@@ -89,7 +89,12 @@ def p_n_poly(
             - (1 - i) * (licon_slots_size[1] + (p_length - licon_slots_size[1]) / 2)
         )
 
-    # generate li (local interconnects) and m1
+        # generate li (local interconnects) and m1
+
+    c.add_ports(ports=cont_arr.ports)
+    c.add_port("p", port=c.ports["e1"])
+    c.add_port("n", port=c.ports["e2"])
+    print(c.ports)
 
     rect_layer = [m1_layer, li_layer]
 


### PR DESCRIPTION
I still can't find how to sort out, but this at least enables the implementation towards the DAC R2R example in gplugins

```
layer (2, 0) not found
layer (0, 0) not found
layer (2, 0) not found
layer (0, 0) not found
layer (2, 0) not found
layer (0, 0) not found
layer (2, 0) not found
layer (0, 0) not found
layer (2, 0) not found
layer (0, 0) not found
layer (2, 0) not found
layer (0, 0) not found
layer (2, 0) not found
layer (0, 0) not found
layer (2, 0) not found
layer (0, 0) not found
layer (2, 0) not found
layer (0, 0) not found
layer (2, 0) not found
layer (0, 0) not found
layer (2, 0) not found
layer (0, 0) not found
layer (2, 0) not found
layer (0, 0) not found
layer (2, 0) not found
layer (0, 0) not found
```

related to https://github.com/gdsfactory/gplugins/pull/356