### PR TITLE
Upgrade gdsfactory to 9.2.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,7 @@ classifiers = [
   "Programming Language :: Python :: 3.12",
   "Operating System :: OS Independent"
 ]
-dependencies = ["gdsfactory>=9.2", "PySpice"]
+dependencies = ["gdsfactory>=9.2.0", "PySpice"]
 description = "skywater130 pdk"
 keywords = ["python"]
 license = {file = "LICENSE"}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,7 @@ classifiers = [
   "Programming Language :: Python :: 3.12",
   "Operating System :: OS Independent"
 ]
-dependencies = ["gdsfactory~=9.0.1", "PySpice"]
+dependencies = ["gdsfactory>=9.2", "PySpice"]
 description = "skywater130 pdk"
 keywords = ["python"]
 license = {file = "LICENSE"}

--- a/uv.lock
+++ b/uv.lock
@@ -1,4 +1,5 @@
 version = 1
+revision = 1
 requires-python = ">=3.11"
 resolution-markers = [
     "python_full_version < '3.12'",
@@ -218,7 +219,7 @@ name = "click"
 version = "8.1.8"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "colorama", marker = "platform_system == 'Windows'" },
+    { name = "colorama", marker = "sys_platform == 'win32'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/b9/2e/0090cbf739cee7d23781ad4b89a9894a41538e4fcf4c31dcdd705b78eb8b/click-8.1.8.tar.gz", hash = "sha256:ed53c9d8990d83c2a27deae68e4ee337473f6330c040a31d4225c9574d16096a", size = 226593 }
 wheels = [
@@ -493,7 +494,7 @@ wheels = [
 
 [[package]]
 name = "gdsfactory"
-version = "9.0.1"
+version = "9.2.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "attrs" },
@@ -527,9 +528,9 @@ dependencies = [
     { name = "typing-extensions" },
     { name = "watchdog" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/8a/48/ec1abe973408c748c4c46b37e1fc94681bdcd57199c9b1c66bb1e7e092ce/gdsfactory-9.0.1.tar.gz", hash = "sha256:35672839416b34d8122e3bcfd573d10415859ade7018e659ad393c33830e9fe6", size = 468274 }
+sdist = { url = "https://files.pythonhosted.org/packages/76/6f/a309e25ec6ff8110e75ce7e8c35e319ee6c158673dd18e3cc3d587aab6cf/gdsfactory-9.2.0.tar.gz", hash = "sha256:8e6eb91a9138e66fc7c8e25c35f7563f6cf9fa6561f950669c079d510a3575e5", size = 469535 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/68/45/e8707c83e10ce253130ab6e782a9cd991d747855d38225230efe6a5363d8/gdsfactory-9.0.1-py3-none-any.whl", hash = "sha256:14117fb1c1f7a8eea13ef747e8a8913fae451c1818f8b9b8354330d11e332716", size = 657321 },
+    { url = "https://files.pythonhosted.org/packages/4d/b8/de3d6c86e39ccda0d33f6ea39fcb07966a9a2324c25f4e592f1a53d9ebe9/gdsfactory-9.2.0-py3-none-any.whl", hash = "sha256:2f2352886542f54a482c8b65b935ce798f60cfdabefa093c04bb8a2bf89f47fb", size = 659544 },
 ]
 
 [[package]]
@@ -685,7 +686,7 @@ name = "ipykernel"
 version = "6.29.5"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "appnope", marker = "platform_system == 'Darwin'" },
+    { name = "appnope", marker = "sys_platform == 'darwin'" },
     { name = "comm" },
     { name = "debugpy" },
     { name = "ipython" },
@@ -909,7 +910,7 @@ wheels = [
 
 [[package]]
 name = "kfactory"
-version = "1.1.3"
+version = "1.2.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "aenum" },
@@ -927,9 +928,9 @@ dependencies = [
     { name = "toolz" },
     { name = "typer" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/84/06/5322cd3dd77587c186290f20083f47b38c77d3d968086070c31d6fbef6a8/kfactory-1.1.3.tar.gz", hash = "sha256:f2da10ec36d3accd6c8886fd0518fd77d01870422f50283a7661247739492b2e", size = 1384872 }
+sdist = { url = "https://files.pythonhosted.org/packages/cc/96/3dfae8b0796bfad7e80c4221a24ab2e132dbbf926059e927c4c0b25b5011/kfactory-1.2.3.tar.gz", hash = "sha256:ea3c89f6f0361e9d68a337c1bbbb0ffd9868a1304da405e809a9609c09d016d3", size = 1383933 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/ab/f4/b8b5d36788fa7ccde439faf942de6eb4fc311cf89edf0edc12802111494b/kfactory-1.1.3-py3-none-any.whl", hash = "sha256:3a4f2c66e122997d30be1ed5b8fe6d29b49392f2a20d84e41d1ae4b6cf56a120", size = 186216 },
+    { url = "https://files.pythonhosted.org/packages/b2/93/89e6d392e5b919e9c551f9d3f5da0547dd0779248b2ecda610a6516a2742/kfactory-1.2.3-py3-none-any.whl", hash = "sha256:f169ba07f436f5f9b7957180553d7ed35c3c26ab3fd901bcb32ff95055962635", size = 187794 },
 ]
 
 [package.optional-dependencies]
@@ -2405,7 +2406,7 @@ wheels = [
 
 [[package]]
 name = "sky130"
-version = "0.12.2"
+version = "0.13.0"
 source = { editable = "." }
 dependencies = [
     { name = "gdsfactory" },
@@ -2428,7 +2429,7 @@ docs = [
 
 [package.metadata]
 requires-dist = [
-    { name = "gdsfactory", specifier = "~=9.0.1" },
+    { name = "gdsfactory", specifier = ">=9.2" },
     { name = "jupyter-book", marker = "extra == 'docs'", specifier = "==1.0.2" },
     { name = "jupytext", marker = "extra == 'docs'" },
     { name = "pre-commit", marker = "extra == 'dev'" },
@@ -2439,6 +2440,7 @@ requires-dist = [
     { name = "pytest-regressions", marker = "extra == 'dev'" },
     { name = "pytest-xdist", marker = "extra == 'dev'" },
 ]
+provides-extras = ["dev", "docs"]
 
 [[package]]
 name = "smmap"


### PR DESCRIPTION
## Summary by Sourcery

Upgrade gdsfactory dependency to version 9.2.0 or higher.