### PR TITLE
Better syntax and update to 9.3.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,7 @@ classifiers = [
   "Programming Language :: Python :: 3.12",
   "Operating System :: OS Independent"
 ]
-dependencies = ["gdsfactory>=9.2.1", "PySpice"]
+dependencies = ["gdsfactory>=9.3.0", "PySpice"]
 description = "skywater130 pdk"
 keywords = ["python"]
 license = {file = "LICENSE"}

--- a/sky130/nmos.py
+++ b/sky130/nmos.py
@@ -53,10 +53,10 @@ def nmos(
         layer=diffusion_layer,
     )
 
-    poly.dymin = -end_cap_length
-    poly.dxmin = 0
+    poly.ymin = -end_cap_length
+    poly.xmin = 0
 
-    diff.dxmin = -sd_width
+    diff.xmin = -sd_width
 
     spacing = np.array(contact_size) + contact_spacing
     spacing = tuple(spacing)
@@ -76,11 +76,11 @@ def nmos(
     contact_array_left = c << contact_array
     contact_array_right = c << contact_array
 
-    contact_array_left.dxmin = -sd_width + contact_enclosure
-    contact_array_left.dymin = contact_enclosure
+    contact_array_left.xmin = -sd_width + contact_enclosure
+    contact_array_left.ymin = contact_enclosure
 
-    contact_array_right.dxmax = diff.dxmax - contact_enclosure
-    contact_array_right.dymin = contact_enclosure
+    contact_array_right.xmax = diff.xmax - contact_enclosure
+    contact_array_right.ymin = contact_enclosure
     return c
 
 

--- a/sky130/pcells/nmos.py
+++ b/sky130/pcells/nmos.py
@@ -143,7 +143,7 @@ def nmos(
         rect_lid, rows=1, columns=nc, column_pitch=con_sp[0], row_pitch=con_sp[1]
     )
 
-    # rect_m1d = gf.components.rectangle(size= ( contact_size[0] + 2*mcon_enclosure[0], cont_arr1.dymax - cont_arr1.dymin + contact_size[1] + 2*mcon_enclosure[1]), layer= m1_layer)
+    # rect_m1d = gf.components.rectangle(size= ( contact_size[0] + 2*mcon_enclosure[0], cont_arr1.ymax - cont_arr1.ymin + contact_size[1] + 2*mcon_enclosure[1]), layer= m1_layer)
     rect_m1d = gf.components.rectangle(
         size=(contact_size[0] + 2 * mcon_enclosure[0], gate_width), layer=m1_layer
     )
@@ -155,27 +155,27 @@ def nmos(
     )
 
     if nc > 1:
-        cont_arr1.dmovex((sd_width - (cont_arr1.dxmax - cont_arr1.dxmin)) / 2)
+        cont_arr1.dmovex((sd_width - (cont_arr1.xmax - cont_arr1.xmin)) / 2)
         cont_arr2.dmovex(
             (nf * (sd_width + gate_length))
-            + ((sd_width - (cont_arr2.dxmax - cont_arr2.dxmin)) / 2)
+            + ((sd_width - (cont_arr2.xmax - cont_arr2.xmin)) / 2)
         )
-        mcont_arr1.dmovex((sd_width - (cont_arr1.dxmax - cont_arr1.dxmin)) / 2)
+        mcont_arr1.dmovex((sd_width - (cont_arr1.xmax - cont_arr1.xmin)) / 2)
         mcont_arr2.dmovex(
             (nf * (sd_width + gate_length))
-            + ((sd_width - (cont_arr2.dxmax - cont_arr2.dxmin)) / 2)
+            + ((sd_width - (cont_arr2.xmax - cont_arr2.xmin)) / 2)
         )
-        li1.dmovex((sd_width - (cont_arr1.dxmax - cont_arr1.dxmin)) / 2)
+        li1.dmovex((sd_width - (cont_arr1.xmax - cont_arr1.xmin)) / 2)
         li2.dmovex(
             (nf * (sd_width + gate_length))
-            + ((sd_width - (cont_arr2.dxmax - cont_arr2.dxmin)) / 2)
+            + ((sd_width - (cont_arr2.xmax - cont_arr2.xmin)) / 2)
         )
         m1d1.dmovex(
-            (sd_width - (cont_arr1.dxmax - cont_arr1.dxmin)) / 2 - mcon_enclosure[0]
+            (sd_width - (cont_arr1.xmax - cont_arr1.xmin)) / 2 - mcon_enclosure[0]
         )
         m1d2.dmovex(
             (nf * (sd_width + gate_length))
-            + ((sd_width - (cont_arr2.dxmax - cont_arr2.dxmin)) / 2)
+            + ((sd_width - (cont_arr2.xmax - cont_arr2.xmin)) / 2)
             - mcon_enclosure[0]
         )
 
@@ -239,7 +239,7 @@ def nmos(
             )
             cont_arr3.dmovex(
                 sd_width
-                + ((gate_length - (cont_arr3.dxmax - cont_arr3.dxmin)) / 2)
+                + ((gate_length - (cont_arr3.xmax - cont_arr3.xmin)) / 2)
                 + (i * (gate_length + sd_width))
             )
             cont_arr3.dmovey(gate_width + end_cap + contact_enclosure[1])
@@ -252,7 +252,7 @@ def nmos(
             )
             cont_arr5.dmovex(
                 sd_width
-                + ((gate_length - (cont_arr5.dxmax - cont_arr5.dxmin)) / 2)
+                + ((gate_length - (cont_arr5.xmax - cont_arr5.xmin)) / 2)
                 + (i * (gate_length + sd_width))
             )
             cont_arr5.dmovey(-contact_size[1] - end_cap - contact_enclosure[1])
@@ -265,7 +265,7 @@ def nmos(
             )
             mcont_arr3.dmovex(
                 sd_width
-                + ((gate_length - (cont_arr3.dxmax - cont_arr3.dxmin)) / 2)
+                + ((gate_length - (cont_arr3.xmax - cont_arr3.xmin)) / 2)
                 + (i * (gate_length + sd_width))
             )
             mcont_arr3.dmovey(gate_width + end_cap + contact_enclosure[1])
@@ -278,7 +278,7 @@ def nmos(
             )
             mcont_arr5.dmovex(
                 sd_width
-                + ((gate_length - (cont_arr5.dxmax - cont_arr5.dxmin)) / 2)
+                + ((gate_length - (cont_arr5.xmax - cont_arr5.xmin)) / 2)
                 + (i * (gate_length + sd_width))
             )
             mcont_arr5.dmovey(-contact_size[1] - end_cap - contact_enclosure[1])
@@ -377,25 +377,25 @@ def nmos(
             l_d
             + diff_spacing
             + sdm_spacing
-            + ((sd_width - (cont_arr4.dxmax - cont_arr4.dxmin)) / 2)
+            + ((sd_width - (cont_arr4.xmax - cont_arr4.xmin)) / 2)
         )
         mcont_arr4.dmovex(
             l_d
             + diff_spacing
             + sdm_spacing
-            + ((sd_width - (cont_arr4.dxmax - cont_arr4.dxmin)) / 2)
+            + ((sd_width - (cont_arr4.xmax - cont_arr4.xmin)) / 2)
         )
         li4.dmovex(
             l_d
             + diff_spacing
             + sdm_spacing
-            + ((sd_width - (cont_arr4.dxmax - cont_arr4.dxmin)) / 2)
+            + ((sd_width - (cont_arr4.xmax - cont_arr4.xmin)) / 2)
         )
         m1dp.dmovex(
             l_d
             + diff_spacing
             + sdm_spacing
-            + ((sd_width - (cont_arr4.dxmax - cont_arr4.dxmin)) / 2)
+            + ((sd_width - (cont_arr4.xmax - cont_arr4.xmin)) / 2)
             - mcon_enclosure[0]
         )
 
@@ -445,8 +445,8 @@ def nmos(
     # generating deep nwell
     rect_dnw = gf.components.rectangle(
         size=(
-            rect_pw.dxmax - rect_pw.dxmin + 2 * dnwell_enclosure[0],
-            rect_pw.dymax - rect_pw.dymin + 2 * dnwell_enclosure[1],
+            rect_pw.xmax - rect_pw.xmin + 2 * dnwell_enclosure[0],
+            rect_pw.ymax - rect_pw.ymin + 2 * dnwell_enclosure[1],
         ),
         layer=dnwell_layer,
     )

--- a/sky130/pcells/nmos_5v.py
+++ b/sky130/pcells/nmos_5v.py
@@ -162,27 +162,27 @@ def nmos_5v(
     )
 
     if nc > 1:
-        cont_arr1.dmovex((sd_width - (cont_arr1.dxmax - cont_arr1.dxmin)) / 2)
+        cont_arr1.dmovex((sd_width - (cont_arr1.xmax - cont_arr1.xmin)) / 2)
         cont_arr2.dmovex(
             (nf * (sd_width + gate_length))
-            + ((sd_width - (cont_arr2.dxmax - cont_arr2.dxmin)) / 2)
+            + ((sd_width - (cont_arr2.xmax - cont_arr2.xmin)) / 2)
         )
-        mcont_arr1.dmovex((sd_width - (cont_arr1.dxmax - cont_arr1.dxmin)) / 2)
+        mcont_arr1.dmovex((sd_width - (cont_arr1.xmax - cont_arr1.xmin)) / 2)
         mcont_arr2.dmovex(
             (nf * (sd_width + gate_length))
-            + ((sd_width - (cont_arr2.dxmax - cont_arr2.dxmin)) / 2)
+            + ((sd_width - (cont_arr2.xmax - cont_arr2.xmin)) / 2)
         )
-        li1.dmovex((sd_width - (cont_arr1.dxmax - cont_arr1.dxmin)) / 2)
+        li1.dmovex((sd_width - (cont_arr1.xmax - cont_arr1.xmin)) / 2)
         li2.dmovex(
             (nf * (sd_width + gate_length))
-            + ((sd_width - (cont_arr2.dxmax - cont_arr2.dxmin)) / 2)
+            + ((sd_width - (cont_arr2.xmax - cont_arr2.xmin)) / 2)
         )
         m1d1.dmovex(
-            (sd_width - (cont_arr1.dxmax - cont_arr1.dxmin)) / 2 - mcon_enclosure[0]
+            (sd_width - (cont_arr1.xmax - cont_arr1.xmin)) / 2 - mcon_enclosure[0]
         )
         m1d2.dmovex(
             (nf * (sd_width + gate_length))
-            + ((sd_width - (cont_arr2.dxmax - cont_arr2.dxmin)) / 2)
+            + ((sd_width - (cont_arr2.xmax - cont_arr2.xmin)) / 2)
             - mcon_enclosure[0]
         )
     else:
@@ -215,7 +215,7 @@ def nmos_5v(
         )
         cont_arr3.dmovex(
             sd_width
-            + ((gate_length - (cont_arr3.dxmax - cont_arr3.dxmin)) / 2)
+            + ((gate_length - (cont_arr3.xmax - cont_arr3.xmin)) / 2)
             + (i * (gate_length + sd_width))
         )
         cont_arr3.dmovey(gate_width + end_cap + contact_enclosure[1])
@@ -224,7 +224,7 @@ def nmos_5v(
         )
         cont_arr5.dmovex(
             sd_width
-            + ((gate_length - (cont_arr5.dxmax - cont_arr5.dxmin)) / 2)
+            + ((gate_length - (cont_arr5.xmax - cont_arr5.xmin)) / 2)
             + (i * (gate_length + sd_width))
         )
         cont_arr5.dmovey(-contact_size[1] - end_cap - contact_enclosure[1])
@@ -234,7 +234,7 @@ def nmos_5v(
         )
         mcont_arr3.dmovex(
             sd_width
-            + ((gate_length - (cont_arr3.dxmax - cont_arr3.dxmin)) / 2)
+            + ((gate_length - (cont_arr3.xmax - cont_arr3.xmin)) / 2)
             + (i * (gate_length + sd_width))
         )
         mcont_arr3.dmovey(gate_width + end_cap + contact_enclosure[1])
@@ -243,7 +243,7 @@ def nmos_5v(
         )
         mcont_arr5.dmovex(
             sd_width
-            + ((gate_length - (cont_arr5.dxmax - cont_arr5.dxmin)) / 2)
+            + ((gate_length - (cont_arr5.xmax - cont_arr5.xmin)) / 2)
             + (i * (gate_length + sd_width))
         )
         mcont_arr5.dmovey(-contact_size[1] - end_cap - contact_enclosure[1])
@@ -338,25 +338,25 @@ def nmos_5v(
             l_d
             + diff_spacing
             + sdm_spacing
-            + ((sd_width - (cont_arr4.dxmax - cont_arr4.dxmin)) / 2)
+            + ((sd_width - (cont_arr4.xmax - cont_arr4.xmin)) / 2)
         )
         mcont_arr4.dmovex(
             l_d
             + diff_spacing
             + sdm_spacing
-            + ((sd_width - (cont_arr4.dxmax - cont_arr4.dxmin)) / 2)
+            + ((sd_width - (cont_arr4.xmax - cont_arr4.xmin)) / 2)
         )
         li4.dmovex(
             l_d
             + diff_spacing
             + sdm_spacing
-            + ((sd_width - (cont_arr4.dxmax - cont_arr4.dxmin)) / 2)
+            + ((sd_width - (cont_arr4.xmax - cont_arr4.xmin)) / 2)
         )
         m1dp.dmovex(
             l_d
             + diff_spacing
             + sdm_spacing
-            + ((sd_width - (cont_arr4.dxmax - cont_arr4.dxmin)) / 2)
+            + ((sd_width - (cont_arr4.xmax - cont_arr4.xmin)) / 2)
             - mcon_enclosure[0]
         )
     else:
@@ -405,8 +405,8 @@ def nmos_5v(
     # generating deep nwell
     rect_dnw = gf.components.rectangle(
         size=(
-            rect_pw.dxmax - rect_pw.dxmin + 2 * dnwell_enclosure[0],
-            rect_pw.dymax - rect_pw.dymin + 2 * dnwell_enclosure[1],
+            rect_pw.xmax - rect_pw.xmin + 2 * dnwell_enclosure[0],
+            rect_pw.ymax - rect_pw.ymin + 2 * dnwell_enclosure[1],
         ),
         layer=dnwell_layer,
     )
@@ -417,8 +417,8 @@ def nmos_5v(
     # generating hvi
     rect_hv = gf.components.rectangle(
         size=(
-            rect_pw.dxmax - rect_pw.dxmin + 2 * dnwell_enclosure[0],
-            rect_pw.dymax - rect_pw.dymin + 2 * dnwell_enclosure[1],
+            rect_pw.xmax - rect_pw.xmin + 2 * dnwell_enclosure[0],
+            rect_pw.ymax - rect_pw.ymin + 2 * dnwell_enclosure[1],
         ),
         layer=hvi_layer,
     )

--- a/sky130/pcells/npn_W1L1.py
+++ b/sky130/pcells/npn_W1L1.py
@@ -240,7 +240,7 @@ def npn_W1L1(
 
     # generate its contacts and local interconnects and mcon and metal1
 
-    nr = ceil((B_in.dymax - B_in.dymin) / (contact_size[1] + contact_spacing[1]))
+    nr = ceil((B_in.ymax - B_in.ymin) / (contact_size[1] + contact_spacing[1]))
     nc = ceil((B_width) / (contact_size[0] + contact_spacing[0]))
 
     if (
@@ -249,7 +249,7 @@ def npn_W1L1(
         nc -= 1
 
     if (
-        (B_in.dymax - B_in.dymin - nr * contact_size[1] - (nr - 1) * contact_spacing[1])
+        (B_in.ymax - B_in.ymin - nr * contact_size[1] - (nr - 1) * contact_spacing[1])
         / 2
     ) < contact_enclosure[1]:
         nr -= 1
@@ -340,8 +340,8 @@ def npn_W1L1(
         )
         cont_B_arr1.dmovey(
             (
-                B_in.dymax
-                - B_in.dymin
+                B_in.ymax
+                - B_in.ymin
                 - nr_b * contact_size[1]
                 - (nr_b - 1) * contact_spacing[1]
             )
@@ -357,8 +357,8 @@ def npn_W1L1(
         )
         cont_B_arr2.dmovey(
             (
-                B_in.dymax
-                - B_in.dymin
+                B_in.ymax
+                - B_in.ymin
                 - nr_b * contact_size[1]
                 - (nr_b - 1) * contact_spacing[1]
             )
@@ -372,8 +372,8 @@ def npn_W1L1(
         cont_B_arr3.dmove((-np_spacing, E_length + np_spacing))
         cont_B_arr3.dmovex(
             (
-                B_in.dxmax
-                - B_in.dxmin
+                B_in.xmax
+                - B_in.xmin
                 - nc_b * contact_size[0]
                 - (nc_b - 1) * contact_spacing[0]
             )
@@ -389,8 +389,8 @@ def npn_W1L1(
         cont_B_arr4.dmove((-np_spacing, -np_spacing - B_width))
         cont_B_arr4.dmovex(
             (
-                B_in.dxmax
-                - B_in.dxmin
+                B_in.xmax
+                - B_in.xmin
                 - nc_b * contact_size[0]
                 - (nc_b - 1) * contact_spacing[0]
             )
@@ -527,7 +527,7 @@ def npn_W1L1(
     c.add_ref(gf.boolean(A=nmC_out, B=nmC_in, operation="not", layer=nsdm_layer))
 
     # generate its contact and local interconnects
-    nr = ceil((C_in.dymax - C_in.dymin) / (contact_size[1] + contact_spacing[1]))
+    nr = ceil((C_in.ymax - C_in.ymin) / (contact_size[1] + contact_spacing[1]))
     nc = ceil((C_width) / (contact_size[0] + contact_spacing[0]))
 
     if (
@@ -536,7 +536,7 @@ def npn_W1L1(
         nc -= 1
 
     if (
-        (C_in.dymax - C_in.dymin - nr * contact_size[1] - (nr - 1) * contact_spacing[1])
+        (C_in.ymax - C_in.ymin - nr * contact_size[1] - (nr - 1) * contact_spacing[1])
         / 2
     ) < contact_enclosure[1]:
         nr -= 1
@@ -628,8 +628,8 @@ def npn_W1L1(
         )
         cont_C_arr1.dmovey(
             (
-                C_in.dymax
-                - C_in.dymin
+                C_in.ymax
+                - C_in.ymin
                 - nr_c * contact_size[1]
                 - (nr_c - 1) * contact_spacing[1]
             )
@@ -647,8 +647,8 @@ def npn_W1L1(
         )
         cont_C_arr2.dmovey(
             (
-                C_in.dymax
-                - C_in.dymin
+                C_in.ymax
+                - C_in.ymin
                 - nr_c * contact_size[1]
                 - (nr_c - 1) * contact_spacing[1]
             )
@@ -664,8 +664,8 @@ def npn_W1L1(
         )
         cont_C_arr3.dmovex(
             (
-                C_in.dxmax
-                - C_in.dxmin
+                C_in.xmax
+                - C_in.xmin
                 - nc_c * contact_size[0]
                 - (nc_c - 1) * contact_spacing[0]
             )
@@ -683,8 +683,8 @@ def npn_W1L1(
         )
         cont_C_arr4.dmovex(
             (
-                C_in.dxmax
-                - C_in.dxmin
+                C_in.xmax
+                - C_in.xmin
                 - nc_c * contact_size[0]
                 - (nc_c - 1) * contact_spacing[0]
             )
@@ -770,8 +770,8 @@ def npn_W1L1(
 
     rect_pwell = gf.components.rectangle(
         size=(
-            B_out.dxmax - B_out.dxmin + 2 * diff_enclosure[0],
-            B_out.dymax - B_out.dymin + 2 * diff_enclosure[1],
+            B_out.xmax - B_out.xmin + 2 * diff_enclosure[0],
+            B_out.ymax - B_out.ymin + 2 * diff_enclosure[1],
         ),
         layer=pwell_layer,
     )
@@ -779,14 +779,14 @@ def npn_W1L1(
     pwell.connect(
         "e1", B_out.ports["e3"], allow_layer_mismatch=True, allow_width_mismatch=True
     )
-    pwell.dmovex(B_out.dxmax - B_out.dxmin + diff_enclosure[0])
+    pwell.dmovex(B_out.xmax - B_out.xmin + diff_enclosure[0])
 
     # generating deep nwell
 
     rect_dnw = gf.components.rectangle(
         size=(
-            C_out.dxmax - C_out.dxmin + 2 * diff_enclosure[0],
-            C_out.dymax - C_out.dymin + 2 * diff_enclosure[1],
+            C_out.xmax - C_out.xmin + 2 * diff_enclosure[0],
+            C_out.ymax - C_out.ymin + 2 * diff_enclosure[1],
         ),
         layer=dnwell_layer,
     )
@@ -794,19 +794,19 @@ def npn_W1L1(
     dnwell.connect(
         "e1", C_out.ports["e3"], allow_layer_mismatch=True, allow_width_mismatch=True
     )
-    dnwell.dmovex(C_out.dxmax - C_out.dxmin + diff_enclosure[0])
+    dnwell.dmovex(C_out.xmax - C_out.xmin + diff_enclosure[0])
 
     # generating npn identifier
 
     npn = c.add_ref(
         gf.components.rectangle(
-            size=(C_out.dxmax - C_out.dxmin, C_out.dymax - C_out.dymin), layer=npn_layer
+            size=(C_out.xmax - C_out.xmin, C_out.ymax - C_out.ymin), layer=npn_layer
         )
     )
     npn.connect(
         "e1", C_out.ports["e3"], allow_layer_mismatch=True, allow_width_mismatch=True
     )
-    npn.dmovex(C_out.dxmax - C_out.dxmin)
+    npn.dmovex(C_out.xmax - C_out.xmin)
     return c
 
 

--- a/sky130/pcells/npn_W1L2.py
+++ b/sky130/pcells/npn_W1L2.py
@@ -238,7 +238,7 @@ def npn_W1L2(
 
     # generate its contacts and local interconnects and mcon and metal1
 
-    nr_v = ceil((B_in.dymax - B_in.dymin) / (contact_size[1] + contact_spacing[1]))
+    nr_v = ceil((B_in.ymax - B_in.ymin) / (contact_size[1] + contact_spacing[1]))
     nc_v = ceil((B_width) / (contact_size[0] + contact_spacing[0]))
 
     if (
@@ -248,8 +248,8 @@ def npn_W1L2(
 
     if (
         (
-            B_in.dymax
-            - B_in.dymin
+            B_in.ymax
+            - B_in.ymin
             - nr_v * contact_size[1]
             - (nr_v - 1) * contact_spacing[1]
         )
@@ -257,7 +257,7 @@ def npn_W1L2(
     ) < contact_enclosure[1]:
         nr_v -= 1
 
-    nc_h = ceil((B_in.dxmax - B_in.dxmin) / (contact_size[0] + contact_spacing[0]))
+    nc_h = ceil((B_in.xmax - B_in.xmin) / (contact_size[0] + contact_spacing[0]))
     nr_h = ceil((B_width) / (contact_size[1] + contact_spacing[1]))
 
     if (
@@ -267,8 +267,8 @@ def npn_W1L2(
 
     if (
         (
-            B_in.dxmax
-            - B_in.dxmin
+            B_in.xmax
+            - B_in.xmin
             - nc_h * contact_size[1]
             - (nc_h - 1) * contact_spacing[1]
         )
@@ -363,8 +363,8 @@ def npn_W1L2(
         )
         cont_B_arr1.dmovey(
             (
-                B_in.dymax
-                - B_in.dymin
+                B_in.ymax
+                - B_in.ymin
                 - nr_v * contact_size[1]
                 - (nr_v - 1) * contact_spacing[1]
             )
@@ -380,8 +380,8 @@ def npn_W1L2(
         )
         cont_B_arr2.dmovey(
             (
-                B_in.dymax
-                - B_in.dymin
+                B_in.ymax
+                - B_in.ymin
                 - nr_v * contact_size[1]
                 - (nr_v - 1) * contact_spacing[1]
             )
@@ -394,8 +394,8 @@ def npn_W1L2(
         cont_B_arr3.dmove((-np_spacing, E_length + np_spacing))
         cont_B_arr3.dmovex(
             (
-                B_in.dxmax
-                - B_in.dxmin
+                B_in.xmax
+                - B_in.xmin
                 - nc_h * contact_size[0]
                 - (nc_h - 1) * contact_spacing[0]
             )
@@ -411,8 +411,8 @@ def npn_W1L2(
         cont_B_arr4.dmove((-np_spacing, -np_spacing - B_width))
         cont_B_arr4.dmovex(
             (
-                B_in.dxmax
-                - B_in.dxmin
+                B_in.xmax
+                - B_in.xmin
                 - nc_h * contact_size[0]
                 - (nc_h - 1) * contact_spacing[0]
             )
@@ -549,7 +549,7 @@ def npn_W1L2(
     c.add_ref(gf.boolean(A=nmC_out, B=nmC_in, operation="A-B", layer=nsdm_layer))
 
     # generate its contact and local interconnects
-    nr_v = ceil((C_in.dymax - C_in.dymin) / (contact_size[1] + contact_spacing[1]))
+    nr_v = ceil((C_in.ymax - C_in.ymin) / (contact_size[1] + contact_spacing[1]))
     nc_v = ceil((C_width) / (contact_size[0] + contact_spacing[0]))
 
     if (
@@ -559,8 +559,8 @@ def npn_W1L2(
 
     if (
         (
-            C_in.dymax
-            - C_in.dymin
+            C_in.ymax
+            - C_in.ymin
             - nr_v * contact_size[1]
             - (nr_v - 1) * contact_spacing[1]
         )
@@ -568,7 +568,7 @@ def npn_W1L2(
     ) < contact_enclosure[1]:
         nr_v -= 1
 
-    nc_h = ceil((C_in.dxmax - C_in.dxmin) / (contact_size[0] + contact_spacing[0]))
+    nc_h = ceil((C_in.xmax - C_in.xmin) / (contact_size[0] + contact_spacing[0]))
     nr_h = ceil((C_width) / (contact_size[1] + contact_spacing[1]))
 
     if (
@@ -578,8 +578,8 @@ def npn_W1L2(
 
     if (
         (
-            C_in.dxmax
-            - C_in.dxmin
+            C_in.xmax
+            - C_in.xmin
             - nc_h * contact_size[1]
             - (nc_h - 1) * contact_spacing[0]
         )
@@ -672,8 +672,8 @@ def npn_W1L2(
         )
         cont_C_arr1.dmovey(
             (
-                C_in.dymax
-                - C_in.dymin
+                C_in.ymax
+                - C_in.ymin
                 - nr_v * contact_size[1]
                 - (nr_v - 1) * contact_spacing[1]
             )
@@ -691,8 +691,8 @@ def npn_W1L2(
         )
         cont_C_arr2.dmovey(
             (
-                C_in.dymax
-                - C_in.dymin
+                C_in.ymax
+                - C_in.ymin
                 - nr_v * contact_size[1]
                 - (nr_v - 1) * contact_spacing[1]
             )
@@ -707,8 +707,8 @@ def npn_W1L2(
         )
         cont_C_arr3.dmovex(
             (
-                C_in.dxmax
-                - C_in.dxmin
+                C_in.xmax
+                - C_in.xmin
                 - nc_h * contact_size[0]
                 - (nc_h - 1) * contact_spacing[0]
             )
@@ -726,8 +726,8 @@ def npn_W1L2(
         )
         cont_C_arr4.dmovex(
             (
-                C_in.dxmax
-                - C_in.dxmin
+                C_in.xmax
+                - C_in.xmin
                 - nc_h * contact_size[0]
                 - (nc_h - 1) * contact_spacing[0]
             )
@@ -813,8 +813,8 @@ def npn_W1L2(
 
     rect_pwell = gf.components.rectangle(
         size=(
-            B_out.dxmax - B_out.dxmin + 2 * diff_enclosure[0],
-            B_out.dymax - B_out.dymin + 2 * diff_enclosure[1],
+            B_out.xmax - B_out.xmin + 2 * diff_enclosure[0],
+            B_out.ymax - B_out.ymin + 2 * diff_enclosure[1],
         ),
         layer=pwell_layer,
     )
@@ -822,13 +822,13 @@ def npn_W1L2(
     pwell.connect(
         "e1", B_out.ports["e3"], allow_layer_mismatch=True, allow_width_mismatch=True
     )
-    pwell.dmovex(B_out.dxmax - B_out.dxmin + diff_enclosure[0])
+    pwell.dmovex(B_out.xmax - B_out.xmin + diff_enclosure[0])
 
     # generating deep nwell
     rect_dnw = gf.components.rectangle(
         size=(
-            C_out.dxmax - C_out.dxmin + 2 * diff_enclosure[0],
-            C_out.dymax - C_out.dymin + 2 * diff_enclosure[1],
+            C_out.xmax - C_out.xmin + 2 * diff_enclosure[0],
+            C_out.ymax - C_out.ymin + 2 * diff_enclosure[1],
         ),
         layer=dnwell_layer,
     )
@@ -836,18 +836,18 @@ def npn_W1L2(
     dnwell.connect(
         "e1", C_out.ports["e3"], allow_layer_mismatch=True, allow_width_mismatch=True
     )
-    dnwell.dmovex(C_out.dxmax - C_out.dxmin + diff_enclosure[0])
+    dnwell.dmovex(C_out.xmax - C_out.xmin + diff_enclosure[0])
 
     # generating npn identifier
     npn = c.add_ref(
         gf.components.rectangle(
-            size=(C_out.dxmax - C_out.dxmin, C_out.dymax - C_out.dymin), layer=npn_layer
+            size=(C_out.xmax - C_out.xmin, C_out.ymax - C_out.ymin), layer=npn_layer
         )
     )
     npn.connect(
         "e1", C_out.ports["e3"], allow_layer_mismatch=True, allow_width_mismatch=True
     )
-    npn.dmovex(C_out.dxmax - C_out.dxmin)
+    npn.dmovex(C_out.xmax - C_out.xmin)
     return c
 
 

--- a/sky130/pcells/p_n_poly.py
+++ b/sky130/pcells/p_n_poly.py
@@ -152,22 +152,22 @@ def p_n_poly(
     rect_mc = gf.components.rectangle(size=contact_size, layer=mcon_layer)
 
     nr_m = ceil(
-        (rect_li_m1.dymax - rect_li_m1.dymin) / (contact_size[1] + contact_spacing[1])
+        (rect_li_m1.ymax - rect_li_m1.ymin) / (contact_size[1] + contact_spacing[1])
     )
     if (
-        rect_li_m1.dymax
-        - rect_li_m1.dymin
+        rect_li_m1.ymax
+        - rect_li_m1.ymin
         - nr_m * contact_size[1]
         - (nr_m - 1) * contact_spacing[1]
     ) / 2 < contact_enclosure[1]:
         nr_m -= 1
 
     nc_m = ceil(
-        (rect_li_m1.dxmax - rect_li_m1.dxmin) / (contact_size[0] + contact_spacing[0])
+        (rect_li_m1.xmax - rect_li_m1.xmin) / (contact_size[0] + contact_spacing[0])
     )
     if (
-        rect_li_m1.dxmax
-        - rect_li_m1.dxmin
+        rect_li_m1.xmax
+        - rect_li_m1.xmin
         - nc_m * contact_size[0]
         - (nc_m - 1) * contact_spacing[0]
     ) < contact_enclosure[0]:
@@ -193,8 +193,8 @@ def p_n_poly(
         )
         mcon_arr.dmovex(
             (
-                rect_li_m1.dxmax
-                - rect_li_m1.dxmin
+                rect_li_m1.xmax
+                - rect_li_m1.xmin
                 - nc_m * contact_size[0]
                 - (nc_m - 1) * contact_spacing[0]
             )
@@ -202,8 +202,8 @@ def p_n_poly(
         )
         mcon_arr.dmovey(
             (
-                rect_li_m1.dymax
-                - rect_li_m1.dymin
+                rect_li_m1.ymax
+                - rect_li_m1.ymin
                 - nr_m * contact_size[1]
                 - (nr_m - 1) * contact_spacing[1]
             )

--- a/sky130/pcells/p_p_poly.py
+++ b/sky130/pcells/p_p_poly.py
@@ -154,22 +154,22 @@ def p_p_poly(
     rect_mc = gf.components.rectangle(size=contact_size, layer=mcon_layer)
 
     nr_m = ceil(
-        (rect_li_m1.dymax - rect_li_m1.dymin) / (contact_size[1] + contact_spacing[1])
+        (rect_li_m1.ymax - rect_li_m1.ymin) / (contact_size[1] + contact_spacing[1])
     )
     if (
-        rect_li_m1.dymax
-        - rect_li_m1.dymin
+        rect_li_m1.ymax
+        - rect_li_m1.ymin
         - nr_m * contact_size[1]
         - (nr_m - 1) * contact_spacing[1]
     ) / 2 < contact_enclosure[1]:
         nr_m -= 1
 
     nc_m = ceil(
-        (rect_li_m1.dxmax - rect_li_m1.dxmin) / (contact_size[0] + contact_spacing[0])
+        (rect_li_m1.xmax - rect_li_m1.xmin) / (contact_size[0] + contact_spacing[0])
     )
     if (
-        rect_li_m1.dxmax
-        - rect_li_m1.dxmin
+        rect_li_m1.xmax
+        - rect_li_m1.xmin
         - nc_m * contact_size[0]
         - (nc_m - 1) * contact_spacing[0]
     ) < contact_enclosure[0]:
@@ -195,8 +195,8 @@ def p_p_poly(
         )
         mcon_arr.dmovex(
             (
-                rect_li_m1.dxmax
-                - rect_li_m1.dxmin
+                rect_li_m1.xmax
+                - rect_li_m1.xmin
                 - nc_m * contact_size[0]
                 - (nc_m - 1) * contact_spacing[0]
             )
@@ -204,8 +204,8 @@ def p_p_poly(
         )
         mcon_arr.dmovey(
             (
-                rect_li_m1.dymax
-                - rect_li_m1.dymin
+                rect_li_m1.ymax
+                - rect_li_m1.ymin
                 - nr_m * contact_size[1]
                 - (nr_m - 1) * contact_spacing[1]
             )

--- a/sky130/pcells/pmos.py
+++ b/sky130/pcells/pmos.py
@@ -154,27 +154,27 @@ def pmos(
     )
 
     if nc > 1:
-        cont_arr1.dmovex((sd_width - (cont_arr1.dxmax - cont_arr1.dxmin)) / 2)
+        cont_arr1.dmovex((sd_width - (cont_arr1.xmax - cont_arr1.xmin)) / 2)
         cont_arr2.dmovex(
             (nf * (sd_width + gate_length))
-            + ((sd_width - (cont_arr2.dxmax - cont_arr2.dxmin)) / 2)
+            + ((sd_width - (cont_arr2.xmax - cont_arr2.xmin)) / 2)
         )
-        mcont_arr1.dmovex((sd_width - (cont_arr1.dxmax - cont_arr1.dxmin)) / 2)
+        mcont_arr1.dmovex((sd_width - (cont_arr1.xmax - cont_arr1.xmin)) / 2)
         mcont_arr2.dmovex(
             (nf * (sd_width + gate_length))
-            + ((sd_width - (cont_arr2.dxmax - cont_arr2.dxmin)) / 2)
+            + ((sd_width - (cont_arr2.xmax - cont_arr2.xmin)) / 2)
         )
-        li1.dmovex((sd_width - (cont_arr1.dxmax - cont_arr1.dxmin)) / 2)
+        li1.dmovex((sd_width - (cont_arr1.xmax - cont_arr1.xmin)) / 2)
         li2.dmovex(
             (nf * (sd_width + gate_length))
-            + ((sd_width - (cont_arr2.dxmax - cont_arr2.dxmin)) / 2)
+            + ((sd_width - (cont_arr2.xmax - cont_arr2.xmin)) / 2)
         )
         m1d1.dmovex(
-            (sd_width - (cont_arr1.dxmax - cont_arr1.dxmin)) / 2 - mcon_enclosure[0]
+            (sd_width - (cont_arr1.xmax - cont_arr1.xmin)) / 2 - mcon_enclosure[0]
         )
         m1d2.dmovex(
             (nf * (sd_width + gate_length))
-            + ((sd_width - (cont_arr2.dxmax - cont_arr2.dxmin)) / 2)
+            + ((sd_width - (cont_arr2.xmax - cont_arr2.xmin)) / 2)
             - mcon_enclosure[0]
         )
     else:
@@ -237,7 +237,7 @@ def pmos(
             )
             cont_arr3.dmovex(
                 sd_width
-                + ((gate_length - (cont_arr3.dxmax - cont_arr3.dxmin)) / 2)
+                + ((gate_length - (cont_arr3.xmax - cont_arr3.xmin)) / 2)
                 + (i * (gate_length + sd_width))
             )
             cont_arr3.dmovey(gate_width + end_cap + contact_enclosure[1])
@@ -250,7 +250,7 @@ def pmos(
             )
             cont_arr5.dmovex(
                 sd_width
-                + ((gate_length - (cont_arr5.dxmax - cont_arr5.dxmin)) / 2)
+                + ((gate_length - (cont_arr5.xmax - cont_arr5.xmin)) / 2)
                 + (i * (gate_length + sd_width))
             )
             cont_arr5.dmovey(-contact_size[1] - end_cap - contact_enclosure[1])
@@ -264,7 +264,7 @@ def pmos(
             )
             mcont_arr3.dmovex(
                 sd_width
-                + ((gate_length - (cont_arr3.dxmax - cont_arr3.dxmin)) / 2)
+                + ((gate_length - (cont_arr3.xmax - cont_arr3.xmin)) / 2)
                 + (i * (gate_length + sd_width))
             )
             mcont_arr3.dmovey(gate_width + end_cap + contact_enclosure[1])
@@ -277,7 +277,7 @@ def pmos(
             )
             mcont_arr5.dmovex(
                 sd_width
-                + ((gate_length - (cont_arr5.dxmax - cont_arr5.dxmin)) / 2)
+                + ((gate_length - (cont_arr5.xmax - cont_arr5.xmin)) / 2)
                 + (i * (gate_length + sd_width))
             )
             mcont_arr5.dmovey(-contact_size[1] - end_cap - contact_enclosure[1])
@@ -376,25 +376,25 @@ def pmos(
             l_d
             + diff_spacing
             + sdm_spacing
-            + ((sd_width - (cont_arr4.dxmax - cont_arr4.dxmin)) / 2)
+            + ((sd_width - (cont_arr4.xmax - cont_arr4.xmin)) / 2)
         )
         mcont_arr4.dmovex(
             l_d
             + diff_spacing
             + sdm_spacing
-            + ((sd_width - (cont_arr4.dxmax - cont_arr4.dxmin)) / 2)
+            + ((sd_width - (cont_arr4.xmax - cont_arr4.xmin)) / 2)
         )
         li4.dmovex(
             l_d
             + diff_spacing
             + sdm_spacing
-            + ((sd_width - (cont_arr4.dxmax - cont_arr4.dxmin)) / 2)
+            + ((sd_width - (cont_arr4.xmax - cont_arr4.xmin)) / 2)
         )
         m1dn.dmovex(
             l_d
             + diff_spacing
             + sdm_spacing
-            + ((sd_width - (cont_arr4.dxmax - cont_arr4.dxmin)) / 2)
+            + ((sd_width - (cont_arr4.xmax - cont_arr4.xmin)) / 2)
             - mcon_enclosure[0]
         )
     else:
@@ -443,8 +443,8 @@ def pmos(
     # generating deep nwell
     rect_dnw = gf.components.rectangle(
         size=(
-            rect_nw.dxmax - rect_nw.dxmin + 2 * dnwell_enclosure[0],
-            rect_nw.dymax - rect_nw.dymin + 2 * dnwell_enclosure[1],
+            rect_nw.xmax - rect_nw.xmin + 2 * dnwell_enclosure[0],
+            rect_nw.ymax - rect_nw.ymin + 2 * dnwell_enclosure[1],
         ),
         layer=dnwell_layer,
     )

--- a/sky130/pcells/pmos_5v.py
+++ b/sky130/pcells/pmos_5v.py
@@ -155,27 +155,27 @@ def pmos_5v(
     )
 
     if nc > 1:
-        cont_arr1.dmovex((sd_width - (cont_arr1.dxmax - cont_arr1.dxmin)) / 2)
+        cont_arr1.dmovex((sd_width - (cont_arr1.xmax - cont_arr1.xmin)) / 2)
         cont_arr2.dmovex(
             (nf * (sd_width + gate_length))
-            + ((sd_width - (cont_arr2.dxmax - cont_arr2.dxmin)) / 2)
+            + ((sd_width - (cont_arr2.xmax - cont_arr2.xmin)) / 2)
         )
-        mcont_arr1.dmovex((sd_width - (cont_arr1.dxmax - cont_arr1.dxmin)) / 2)
+        mcont_arr1.dmovex((sd_width - (cont_arr1.xmax - cont_arr1.xmin)) / 2)
         mcont_arr2.dmovex(
             (nf * (sd_width + gate_length))
-            + ((sd_width - (cont_arr2.dxmax - cont_arr2.dxmin)) / 2)
+            + ((sd_width - (cont_arr2.xmax - cont_arr2.xmin)) / 2)
         )
-        li1.dmovex((sd_width - (cont_arr1.dxmax - cont_arr1.dxmin)) / 2)
+        li1.dmovex((sd_width - (cont_arr1.xmax - cont_arr1.xmin)) / 2)
         li2.dmovex(
             (nf * (sd_width + gate_length))
-            + ((sd_width - (cont_arr2.dxmax - cont_arr2.dxmin)) / 2)
+            + ((sd_width - (cont_arr2.xmax - cont_arr2.xmin)) / 2)
         )
         m1d1.dmovex(
-            (sd_width - (cont_arr1.dxmax - cont_arr1.dxmin)) / 2 - mcon_enclosure[0]
+            (sd_width - (cont_arr1.xmax - cont_arr1.xmin)) / 2 - mcon_enclosure[0]
         )
         m1d2.dmovex(
             (nf * (sd_width + gate_length))
-            + ((sd_width - (cont_arr2.dxmax - cont_arr2.dxmin)) / 2)
+            + ((sd_width - (cont_arr2.xmax - cont_arr2.xmin)) / 2)
             - mcon_enclosure[0]
         )
     else:
@@ -208,7 +208,7 @@ def pmos_5v(
         )
         cont_arr3.dmovex(
             sd_width
-            + ((gate_length - (cont_arr3.dxmax - cont_arr3.dxmin)) / 2)
+            + ((gate_length - (cont_arr3.xmax - cont_arr3.xmin)) / 2)
             + (i * (gate_length + sd_width))
         )
         cont_arr3.dmovey(gate_width + end_cap + contact_enclosure[1])
@@ -217,7 +217,7 @@ def pmos_5v(
         )
         cont_arr5.dmovex(
             sd_width
-            + ((gate_length - (cont_arr5.dxmax - cont_arr5.dxmin)) / 2)
+            + ((gate_length - (cont_arr5.xmax - cont_arr5.xmin)) / 2)
             + (i * (gate_length + sd_width))
         )
         cont_arr5.dmovey(-contact_size[1] - end_cap - contact_enclosure[1])
@@ -227,7 +227,7 @@ def pmos_5v(
         )
         mcont_arr3.dmovex(
             sd_width
-            + ((gate_length - (cont_arr3.dxmax - cont_arr3.dxmin)) / 2)
+            + ((gate_length - (cont_arr3.xmax - cont_arr3.xmin)) / 2)
             + (i * (gate_length + sd_width))
         )
         mcont_arr3.dmovey(gate_width + end_cap + contact_enclosure[1])
@@ -236,7 +236,7 @@ def pmos_5v(
         )
         mcont_arr5.dmovex(
             sd_width
-            + ((gate_length - (cont_arr5.dxmax - cont_arr5.dxmin)) / 2)
+            + ((gate_length - (cont_arr5.xmax - cont_arr5.xmin)) / 2)
             + (i * (gate_length + sd_width))
         )
         mcont_arr5.dmovey(-contact_size[1] - end_cap - contact_enclosure[1])
@@ -331,25 +331,25 @@ def pmos_5v(
             l_d
             + diff_spacing
             + sdm_spacing
-            + ((sd_width - (cont_arr4.dxmax - cont_arr4.dxmin)) / 2)
+            + ((sd_width - (cont_arr4.xmax - cont_arr4.xmin)) / 2)
         )
         mcont_arr4.dmovex(
             l_d
             + diff_spacing
             + sdm_spacing
-            + ((sd_width - (cont_arr4.dxmax - cont_arr4.dxmin)) / 2)
+            + ((sd_width - (cont_arr4.xmax - cont_arr4.xmin)) / 2)
         )
         li4.dmovex(
             l_d
             + diff_spacing
             + sdm_spacing
-            + ((sd_width - (cont_arr4.dxmax - cont_arr4.dxmin)) / 2)
+            + ((sd_width - (cont_arr4.xmax - cont_arr4.xmin)) / 2)
         )
         m1dn.dmovex(
             l_d
             + diff_spacing
             + sdm_spacing
-            + ((sd_width - (cont_arr4.dxmax - cont_arr4.dxmin)) / 2)
+            + ((sd_width - (cont_arr4.xmax - cont_arr4.xmin)) / 2)
             - mcon_enclosure[0]
         )
     else:
@@ -398,8 +398,8 @@ def pmos_5v(
     # generating deep nwell
     rect_dnw = gf.components.rectangle(
         size=(
-            rect_nw.dxmax - rect_nw.dxmin + 2 * dnwell_enclosure[0],
-            rect_nw.dymax - rect_nw.dymin + 2 * dnwell_enclosure[1],
+            rect_nw.xmax - rect_nw.xmin + 2 * dnwell_enclosure[0],
+            rect_nw.ymax - rect_nw.ymin + 2 * dnwell_enclosure[1],
         ),
         layer=dnwell_layer,
     )
@@ -410,8 +410,8 @@ def pmos_5v(
     # generating hvi
     rect_hv = gf.components.rectangle(
         size=(
-            rect_nw.dxmax - rect_nw.dxmin + 2 * dnwell_enclosure[0],
-            rect_nw.dymax - rect_nw.dymin + 2 * dnwell_enclosure[1],
+            rect_nw.xmax - rect_nw.xmin + 2 * dnwell_enclosure[0],
+            rect_nw.ymax - rect_nw.ymin + 2 * dnwell_enclosure[1],
         ),
         layer=hvi_layer,
     )

--- a/sky130/pcells/pnp.py
+++ b/sky130/pcells/pnp.py
@@ -214,7 +214,7 @@ def pnp(
 
     # generate its contacts and local interconnects and mcon and metal1
 
-    nr_v = ceil((B_in.dymax - B_in.dymin) / (contact_size[1] + contact_spacing[1]))
+    nr_v = ceil((B_in.ymax - B_in.ymin) / (contact_size[1] + contact_spacing[1]))
     nc_v = ceil((B_width) / (contact_size[0] + contact_spacing[0]))
 
     if (
@@ -224,8 +224,8 @@ def pnp(
 
     if (
         (
-            B_in.dymax
-            - B_in.dymin
+            B_in.ymax
+            - B_in.ymin
             - nr_v * contact_size[1]
             - (nr_v - 1) * contact_spacing[1]
         )
@@ -233,7 +233,7 @@ def pnp(
     ) < contact_enclosure[1]:
         nr_v -= 1
 
-    nc_h = ceil((B_in.dxmax - B_in.dxmin) / (contact_size[0] + contact_spacing[0]))
+    nc_h = ceil((B_in.xmax - B_in.xmin) / (contact_size[0] + contact_spacing[0]))
     nr_h = ceil((B_width) / (contact_size[1] + contact_spacing[1]))
 
     if (
@@ -243,8 +243,8 @@ def pnp(
 
     if (
         (
-            B_in.dxmax
-            - B_in.dxmin
+            B_in.xmax
+            - B_in.xmin
             - nc_h * contact_size[1]
             - (nc_h - 1) * contact_spacing[1]
         )
@@ -338,8 +338,8 @@ def pnp(
         )
         cont_B_arr1.dmovey(
             (
-                B_in.dymax
-                - B_in.dymin
+                B_in.ymax
+                - B_in.ymin
                 - nr_v * contact_size[1]
                 - (nr_v - 1) * contact_spacing[1]
             )
@@ -355,8 +355,8 @@ def pnp(
         )
         cont_B_arr2.dmovey(
             (
-                B_in.dymax
-                - B_in.dymin
+                B_in.ymax
+                - B_in.ymin
                 - nr_v * contact_size[1]
                 - (nr_v - 1) * contact_spacing[1]
             )
@@ -369,8 +369,8 @@ def pnp(
         cont_B_arr3.dmove((-np_spacing, E_length + np_spacing))
         cont_B_arr3.dmovex(
             (
-                B_in.dxmax
-                - B_in.dxmin
+                B_in.xmax
+                - B_in.xmin
                 - nc_h * contact_size[0]
                 - (nc_h - 1) * contact_spacing[0]
             )
@@ -386,8 +386,8 @@ def pnp(
         cont_B_arr4.dmove((-np_spacing, -np_spacing - B_width))
         cont_B_arr4.dmovex(
             (
-                B_in.dxmax
-                - B_in.dxmin
+                B_in.xmax
+                - B_in.xmin
                 - nc_h * contact_size[0]
                 - (nc_h - 1) * contact_spacing[0]
             )
@@ -524,7 +524,7 @@ def pnp(
     c.add_ref(gf.boolean(A=pmC_out, B=pmC_in, operation="A-B", layer=psdm_layer))
 
     # generate its contact and local interconnects
-    nr_v = ceil((C_in.dymax - C_in.dymin) / (contact_size[1] + contact_spacing[1]))
+    nr_v = ceil((C_in.ymax - C_in.ymin) / (contact_size[1] + contact_spacing[1]))
     nc_v = ceil((C_width) / (contact_size[0] + contact_spacing[0]))
 
     if (
@@ -534,8 +534,8 @@ def pnp(
 
     if (
         (
-            C_in.dymax
-            - C_in.dymin
+            C_in.ymax
+            - C_in.ymin
             - nr_v * contact_size[1]
             - (nr_v - 1) * contact_spacing[1]
         )
@@ -543,7 +543,7 @@ def pnp(
     ) < contact_enclosure[1]:
         nr_v -= 1
 
-    nc_h = ceil((C_in.dxmax - C_in.dxmin) / (contact_size[0] + contact_spacing[0]))
+    nc_h = ceil((C_in.xmax - C_in.xmin) / (contact_size[0] + contact_spacing[0]))
     nr_h = ceil((C_width) / (contact_size[1] + contact_spacing[1]))
 
     if (
@@ -553,8 +553,8 @@ def pnp(
 
     if (
         (
-            C_in.dxmax
-            - C_in.dxmin
+            C_in.xmax
+            - C_in.xmin
             - nc_h * contact_size[1]
             - (nc_h - 1) * contact_spacing[0]
         )
@@ -647,8 +647,8 @@ def pnp(
         )
         cont_C_arr1.dmovey(
             (
-                C_in.dymax
-                - C_in.dymin
+                C_in.ymax
+                - C_in.ymin
                 - nr_v * contact_size[1]
                 - (nr_v - 1) * contact_spacing[1]
             )
@@ -666,8 +666,8 @@ def pnp(
         )
         cont_C_arr2.dmovey(
             (
-                C_in.dymax
-                - C_in.dymin
+                C_in.ymax
+                - C_in.ymin
                 - nr_v * contact_size[1]
                 - (nr_v - 1) * contact_spacing[1]
             )
@@ -682,8 +682,8 @@ def pnp(
         )
         cont_C_arr3.dmovex(
             (
-                C_in.dxmax
-                - C_in.dxmin
+                C_in.xmax
+                - C_in.xmin
                 - nc_h * contact_size[0]
                 - (nc_h - 1) * contact_spacing[0]
             )
@@ -701,8 +701,8 @@ def pnp(
         )
         cont_C_arr4.dmovex(
             (
-                C_in.dxmax
-                - C_in.dxmin
+                C_in.xmax
+                - C_in.xmin
                 - nc_h * contact_size[0]
                 - (nc_h - 1) * contact_spacing[0]
             )
@@ -788,8 +788,8 @@ def pnp(
 
     rect_nwell = gf.components.rectangle(
         size=(
-            B_out.dxmax - B_out.dxmin + 2 * diff_enclosure[0],
-            B_out.dymax - B_out.dymin + 2 * diff_enclosure[1],
+            B_out.xmax - B_out.xmin + 2 * diff_enclosure[0],
+            B_out.ymax - B_out.ymin + 2 * diff_enclosure[1],
         ),
         layer=nwell_layer,
     )
@@ -797,18 +797,18 @@ def pnp(
     nwell.connect(
         "e1", B_out.ports["e3"], allow_layer_mismatch=True, allow_width_mismatch=True
     )
-    nwell.dmovex(B_out.dxmax - B_out.dxmin + diff_enclosure[0])
+    nwell.dmovex(B_out.xmax - B_out.xmin + diff_enclosure[0])
 
     # generating pnp identifier
     npn = c.add_ref(
         gf.components.rectangle(
-            size=(C_out.dxmax - C_out.dxmin, C_out.dymax - C_out.dymin), layer=pnp_layer
+            size=(C_out.xmax - C_out.xmin, C_out.ymax - C_out.ymin), layer=pnp_layer
         )
     )
     npn.connect(
         "e1", C_out.ports["e3"], allow_layer_mismatch=True, allow_width_mismatch=True
     )
-    npn.dmovex(C_out.dxmax - C_out.dxmin)
+    npn.dmovex(C_out.xmax - C_out.xmin)
     return c
 
 

--- a/sky130/pcells/via_generator.py
+++ b/sky130/pcells/via_generator.py
@@ -118,8 +118,8 @@ def demo_via():
 
     for i in range(2):
         v = via_generator(
-            width=x2.dxmax - x1.dxmax,
-            length=x1.dymax - x1.dymin,
+            width=x2.xmax - x1.xmax,
+            length=x1.ymax - x1.ymin,
             via_enclosure=via_enclosure,
             via_size=via_size,
             via_spacing=via_spacing,
@@ -127,19 +127,19 @@ def demo_via():
         )
         vi = c2.add_ref(v)
         vi.dmovex(
-            (x2.dxmax - x1.dxmax - nc * via_size[0] - (nc - 1) * via_spacing[0]) / 2
-            + i * (x2.dxmax - x1.dxmin)
+            (x2.xmax - x1.xmax - nc * via_size[0] - (nc - 1) * via_spacing[0]) / 2
+            + i * (x2.xmax - x1.xmin)
         )
         vi.dmovey(
-            x1.dymin
-            - x2.dymin
-            + (x1.dymax - x1.dymin - nr * via_size[1] - (nr - 1) * via_spacing[1]) / 2
+            x1.ymin
+            - x2.ymin
+            + (x1.ymax - x1.ymin - nr * via_size[1] - (nr - 1) * via_spacing[1]) / 2
         )
 
     for i in range(2):
         h = via_generator(
-            width=x1.dxmax - x1.dxmin,
-            length=x2.dymax - x1.dymax,
+            width=x1.xmax - x1.xmin,
+            length=x2.ymax - x1.ymax,
             via_enclosure=via_enclosure,
             via_size=via_size,
             via_spacing=via_spacing,
@@ -147,20 +147,20 @@ def demo_via():
         )
         vi = c2.add_ref(h)
         vi.dmovey(
-            (x2.dymax - x1.dymax - nr * via_size[1] - (nr - 1) * via_spacing[1]) / 2
-            + i * (x2.dymax - x1.dymin)
+            (x2.ymax - x1.ymax - nr * via_size[1] - (nr - 1) * via_spacing[1]) / 2
+            + i * (x2.ymax - x1.ymin)
         )
         vi.dmovex(
-            x1.dxmin
-            - x2.dxmin
-            + (x1.dxmax - x1.dxmin - nc * via_size[0] - (nc - 1) * via_spacing[0]) / 2
+            x1.xmin
+            - x2.xmin
+            + (x1.xmax - x1.xmin - nc * via_size[0] - (nc - 1) * via_spacing[0]) / 2
         )
 
     for i in range(2):
         for j in range(2):
             cor = via_generator(
-                width=x2.dxmax - x1.dxmax,
-                length=x2.dymax - x1.dymax,
+                width=x2.xmax - x1.xmax,
+                length=x2.ymax - x1.ymax,
                 via_enclosure=via_enclosure,
                 via_size=via_size,
                 via_spacing=via_spacing,
@@ -169,13 +169,13 @@ def demo_via():
 
             co = c2.add_ref(cor)
             co.dmovex(
-                (x2.dxmax - x1.dxmax - nc * via_size[0] - (nc - 1) * via_spacing[0]) / 2
+                (x2.xmax - x1.xmax - nc * via_size[0] - (nc - 1) * via_spacing[0]) / 2
             )
             co.dmovey(
-                (x1.dymin - x2.dymin - nr * via_size[1] - (nr - 1) * via_spacing[1]) / 2
+                (x1.ymin - x2.ymin - nr * via_size[1] - (nr - 1) * via_spacing[1]) / 2
             )
-            co.dmovex(j * (x2.dxmax - x1.dxmin))
-            co.dmovey(i * (x2.dymax - x1.dymin))
+            co.dmovex(j * (x2.xmax - x1.xmin))
+            co.dmovey(i * (x2.ymax - x1.ymin))
 
     return c2
 


### PR DESCRIPTION
## Summary by Sourcery

Fixes syntax errors and updates the gdsfactory dependency to version 9.3.0.

Bug Fixes:
- Fixes syntax errors in the calculation of contact arrays in pcells.
- Corrects the calculation of the number of contacts in the npn_W1L2, pnp, and npn_W1L1 pcells.
- Fixes placement of contacts and deep nwell in nmos and pmos 5V pcells.
- Addresses issues in via generation and placement in the via_generator pcell.
- Resolves placement issues in metal and contact layers in nmos and pmos pcells.
- Fixes contact array calculations in p_n_poly and p_p_poly pcells.

Enhancements:
- Updates gdsfactory dependency to version 9.3.0.