### PR TITLE
better type annotations

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ Then you need to restart Klayout to make sure the new technology installed appea
 Then you can install with:
 
 ```bash
-git clone https://github.com/gdsfactory/sky130.git
+git clone https://github.com/gdsfactory/skywater130.git
 cd sky130
 make install
 uv venv --python 3.12

--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -49,9 +49,32 @@ sphinx:
     - "matplotlib.sphinxext.plot_directive"
   config:
     #autodoc_typehints: description
+    autodoc_typehints: description
+    autodoc_typehints_format: short
+    python_use_unqualified_type_names: True
     autodoc_type_aliases:
+      "ComponentFactory": "ComponentFactory"
       "ComponentSpec": "ComponentSpec"
-    nb_execution_show_tb: True
+      "CrossSectionFactory": "CrossSectionFactory"
+      "CrossSectionSpec": "CrossSectionSpec"
+      "LayerSpec": "LayerSpec"
+      "LayerSpecs": "LayerSpecs"
+      "Layer": "Layer"
+      "Layers": "Layers"
+      "PathType": "PathType"
+      "SDict": "sax.SDict"
+      "sax.SDict": "sax.SDict"
+      "gdsfactory.typings.ComponentFactory": "ComponentFactory"
+      "gdsfactory.typings.ComponentSpec": "ComponentSpec"
+      "gdsfactory.typings.CrossSectionFactory": "CrossSectionFactory"
+      "gdsfactory.typings.CrossSectionSpec": "CrossSectionSpec"
+      "gdsfactory.typings.LayerSpec": "LayerSpec"
+      "gdsfactory.typings.LayerSpecs": "LayerSpecs"
+      "gdsfactory.typings.Layer": "Layer"
+      "gdsfactory.typings.Layers": "Layers"
+      "gdsfactory.typings.PathType": "PathType"
+      "CrossSection | str | dict[str, Any] | Callable[[...], CrossSection] | SymmetricalCrossSection | DCrossSection": "CrossSectionSpec"
+      "Component | ComponentAllAngle | str | dict[str, Any] | Callable[[...], Component]": "ComponentSpec"
     # nb_custom_formats:
     #     .py:
     #         - jupytext.reads

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,7 @@ classifiers = [
   "Operating System :: OS Independent"
 ]
 dependencies = [
-  "gdsfactory~=9.14.2",
+  "gdsfactory~=9.15.0",
   "PySpice"
 ]
 description = "skywater130 pdk"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,7 @@ classifiers = [
   "Operating System :: OS Independent"
 ]
 dependencies = [
-  "gdsfactory~=9.8.0",
+  "gdsfactory~=9.14.2",
   "PySpice"
 ]
 description = "skywater130 pdk"

--- a/tests/test_components/test_pdk_settings_bend_metal1_.yml
+++ b/tests/test_components/test_pdk_settings_bend_metal1_.yml
@@ -1,0 +1,15 @@
+info:
+  dy: 0.2
+  length: 0.312
+  radius: 0.2
+  route_info_length: 0.312
+  route_info_metal1_length: 0.312
+  route_info_min_bend_radius: 0.2
+  route_info_n_bend_90: 1
+  route_info_type: metal1
+  route_info_weight: 0.312
+  width: 0.2
+name: bend_metal1_RNone_A90_WNone_CSmetal1
+settings:
+  angle: 90
+  cross_section: metal1

--- a/tests/test_components/test_pdk_settings_bend_metal2_.yml
+++ b/tests/test_components/test_pdk_settings_bend_metal2_.yml
@@ -1,0 +1,15 @@
+info:
+  dy: 0.2
+  length: 0.312
+  radius: 0.2
+  route_info_length: 0.312
+  route_info_metal2_length: 0.312
+  route_info_min_bend_radius: 0.2
+  route_info_n_bend_90: 1
+  route_info_type: metal2
+  route_info_weight: 0.312
+  width: 0.2
+name: bend_metal2_RNone_A90_WNone_CSmetal2
+settings:
+  angle: 90
+  cross_section: metal2

--- a/tests/test_components/test_pdk_settings_bend_s_metal1_.yml
+++ b/tests/test_components/test_pdk_settings_bend_s_metal1_.yml
@@ -1,0 +1,17 @@
+info:
+  end_angle: 0
+  length: 11.206
+  min_bend_radius: 13.012
+  route_info_length: 11.206
+  route_info_metal1_length: 11.206
+  route_info_min_bend_radius: 13.012
+  route_info_n_bend_s: 1
+  route_info_type: metal1
+  route_info_weight: 11.206
+  start_angle: 0
+name: bend_s_metal1_S11_1p8_CSmetal1_WNone
+settings:
+  cross_section: metal1
+  size:
+  - 11
+  - 1.8

--- a/tests/test_components/test_pdk_settings_bend_s_metal2_.yml
+++ b/tests/test_components/test_pdk_settings_bend_s_metal2_.yml
@@ -1,0 +1,17 @@
+info:
+  end_angle: 0
+  length: 11.206
+  min_bend_radius: 13.012
+  route_info_length: 11.206
+  route_info_metal2_length: 11.206
+  route_info_min_bend_radius: 13.012
+  route_info_n_bend_s: 1
+  route_info_type: metal2
+  route_info_weight: 11.206
+  start_angle: 0
+name: bend_s_metal2_S11_1p8_CSmetal2_WNone
+settings:
+  cross_section: metal2
+  size:
+  - 11
+  - 1.8

--- a/tests/test_components/test_pdk_settings_mimcap_1_.yml
+++ b/tests/test_components/test_pdk_settings_mimcap_1_.yml
@@ -1,5 +1,5 @@
 info: {}
-name: mimcap_1_ML70_20_VS0p2__4e676e6d
+name: mimcap_1_ML70_20_VS0p2_0p2_VL70_44_VS0p2_0p2_MS0p3_MRL0_4e676e6d
 settings:
   capm_enclosure:
   - 0.5

--- a/tests/test_components/test_pdk_settings_mimcap_2_.yml
+++ b/tests/test_components/test_pdk_settings_mimcap_2_.yml
@@ -1,5 +1,5 @@
 info: {}
-name: mimcap_2_ML71_20_VS0p8__ca87d042
+name: mimcap_2_ML71_20_VS0p8_0p8_VL71_44_VS0p8_0p8_MS1p6_MRL1_ca87d042
 settings:
   capm2_enclosure:
   - 0.5

--- a/tests/test_components/test_pdk_settings_nmos_.yml
+++ b/tests/test_components/test_pdk_settings_nmos_.yml
@@ -1,5 +1,5 @@
 info: {}
-name: nmos_DL65_20_PL66_20_GW_6749bf57
+name: nmos_DL65_20_PL66_20_GW0p42_GL0p15_SW0p3_EC0p13_CS0p17__6749bf57
 settings:
   contact_enclosure:
   - 0.06

--- a/tests/test_components/test_pdk_settings_nmos_5v_.yml
+++ b/tests/test_components/test_pdk_settings_nmos_5v_.yml
@@ -1,5 +1,5 @@
 info: {}
-name: nmos_5v_DL65_20_PL66_20_6d78cadc
+name: nmos_5v_DL65_20_PL66_20_GW0p75_GL0p5_SW0p3_EC0p13_CS0p1_6d78cadc
 settings:
   contact_enclosure:
   - 0.06

--- a/tests/test_components/test_pdk_settings_npn_W1L1_.yml
+++ b/tests/test_components/test_pdk_settings_npn_W1L1_.yml
@@ -1,5 +1,5 @@
 info: {}
-name: npn_W1L1_EW1_EL1_BW0p4__1fd7211c
+name: npn_W1L1_EW1_EL1_BW0p4_CW0p4_NS0p27_DL65_20_TL65_44_DE0_1fd7211c
 settings:
   B_width: 0.4
   C_width: 0.4

--- a/tests/test_components/test_pdk_settings_npn_W1L2_.yml
+++ b/tests/test_components/test_pdk_settings_npn_W1L2_.yml
@@ -1,5 +1,5 @@
 info: {}
-name: npn_W1L2_EW1_EL2_BW0p4__7e7949df
+name: npn_W1L2_EW1_EL2_BW0p4_CW0p4_NS0p27_DL65_20_TL65_44_DE0_7e7949df
 settings:
   B_width: 0.4
   C_width: 0.4

--- a/tests/test_components/test_pdk_settings_p_n_poly_.yml
+++ b/tests/test_components/test_pdk_settings_p_n_poly_.yml
@@ -1,5 +1,5 @@
 info: {}
-name: p_n_poly_PPW0p35_PPL0p5_1bc43356
+name: p_n_poly_PPW0p35_PPL0p5_PRL66_13_PL66_20_PL94_20_SE0p12_1bc43356
 settings:
   contact_enclosure:
   - 0.06

--- a/tests/test_components/test_pdk_settings_p_p_poly_.yml
+++ b/tests/test_components/test_pdk_settings_p_p_poly_.yml
@@ -1,5 +1,5 @@
 info: {}
-name: p_p_poly_PPW0p35_PPL0p5_15dc4c48
+name: p_p_poly_PPW0p35_PPL0p5_PRL66_13_PL66_20_PL94_20_SE0p12_15dc4c48
 settings:
   contact_enclosure:
   - 0.06

--- a/tests/test_components/test_pdk_settings_pmos_.yml
+++ b/tests/test_components/test_pdk_settings_pmos_.yml
@@ -1,5 +1,5 @@
 info: {}
-name: pmos_DL65_20_PL66_20_GW_7865e95a
+name: pmos_DL65_20_PL66_20_GW0p42_GL0p15_SW0p3_EC0p13_CS0p17__7865e95a
 settings:
   contact_enclosure:
   - 0.06

--- a/tests/test_components/test_pdk_settings_pmos_5v_.yml
+++ b/tests/test_components/test_pdk_settings_pmos_5v_.yml
@@ -1,5 +1,5 @@
 info: {}
-name: pmos_5v_DL65_20_PL66_20_53db6c9d
+name: pmos_5v_DL65_20_PL66_20_GW0p75_GL0p5_SW0p3_EC0p13_CS0p1_53db6c9d
 settings:
   contact_enclosure:
   - 0.06

--- a/tests/test_components/test_pdk_settings_pnp_.yml
+++ b/tests/test_components/test_pdk_settings_pnp_.yml
@@ -1,5 +1,5 @@
 info: {}
-name: pnp_EW0p68_EL0p68_BW0p4_adad27c3
+name: pnp_EW0p68_EL0p68_BW0p4_CW0p4_NS0p27_DL65_20_TL65_44_DE_adad27c3
 settings:
   B_width: 0.4
   C_width: 0.4

--- a/tests/test_components/test_pdk_settings_sky130_fd_pr__cap_vpp_02p4x04p6_m1m2_noshield_.yml
+++ b/tests/test_components/test_pdk_settings_sky130_fd_pr__cap_vpp_02p4x04p6_m1m2_noshield_.yml
@@ -1,3 +1,3 @@
 info: {}
-name: sky130_fd_pr__cap_vpp_0_99428920
+name: sky130_fd_pr__cap_vpp_02p4x04p6_m1m2_noshield
 settings: {}

--- a/tests/test_components/test_pdk_settings_sky130_fd_pr__cap_vpp_02p7x06p1_m1m2m3m4_shieldl1_fingercap_.yml
+++ b/tests/test_components/test_pdk_settings_sky130_fd_pr__cap_vpp_02p7x06p1_m1m2m3m4_shieldl1_fingercap_.yml
@@ -1,3 +1,3 @@
 info: {}
-name: sky130_fd_pr__cap_vpp_0_dd872f25
+name: sky130_fd_pr__cap_vpp_02p7x06p1_m1m2m3m4_shieldl1_fingercap
 settings: {}

--- a/tests/test_components/test_pdk_settings_sky130_fd_pr__cap_vpp_02p7x11p1_m1m2m3m4_shieldl1_fingercap_.yml
+++ b/tests/test_components/test_pdk_settings_sky130_fd_pr__cap_vpp_02p7x11p1_m1m2m3m4_shieldl1_fingercap_.yml
@@ -1,3 +1,3 @@
 info: {}
-name: sky130_fd_pr__cap_vpp_0_ace8b399
+name: sky130_fd_pr__cap_vpp_02p7x11p1_m1m2m3m4_shieldl1_fingercap
 settings: {}

--- a/tests/test_components/test_pdk_settings_sky130_fd_pr__cap_vpp_02p7x21p1_m1m2m3m4_shieldl1_fingercap_.yml
+++ b/tests/test_components/test_pdk_settings_sky130_fd_pr__cap_vpp_02p7x21p1_m1m2m3m4_shieldl1_fingercap_.yml
@@ -1,3 +1,3 @@
 info: {}
-name: sky130_fd_pr__cap_vpp_0_907893ed
+name: sky130_fd_pr__cap_vpp_02p7x21p1_m1m2m3m4_shieldl1_fingercap
 settings: {}

--- a/tests/test_components/test_pdk_settings_sky130_fd_pr__cap_vpp_02p7x41p1_m1m2m3m4_shieldl1_fingercap_.yml
+++ b/tests/test_components/test_pdk_settings_sky130_fd_pr__cap_vpp_02p7x41p1_m1m2m3m4_shieldl1_fingercap_.yml
@@ -1,3 +1,3 @@
 info: {}
-name: sky130_fd_pr__cap_vpp_0_241341c7
+name: sky130_fd_pr__cap_vpp_02p7x41p1_m1m2m3m4_shieldl1_fingercap
 settings: {}

--- a/tests/test_components/test_pdk_settings_sky130_fd_pr__cap_vpp_02p9x06p1_m1m2m3m4_shieldl1_fingercap2_.yml
+++ b/tests/test_components/test_pdk_settings_sky130_fd_pr__cap_vpp_02p9x06p1_m1m2m3m4_shieldl1_fingercap2_.yml
@@ -1,3 +1,3 @@
 info: {}
-name: sky130_fd_pr__cap_vpp_0_4f464c8f
+name: sky130_fd_pr__cap_vpp_02p9x06p1_m1m2m3m4_shieldl1_fingercap2
 settings: {}

--- a/tests/test_components/test_pdk_settings_sky130_fd_pr__cap_vpp_03p9x03p9_m1m2_shieldl1_floatm3_.yml
+++ b/tests/test_components/test_pdk_settings_sky130_fd_pr__cap_vpp_03p9x03p9_m1m2_shieldl1_floatm3_.yml
@@ -1,3 +1,3 @@
 info: {}
-name: sky130_fd_pr__cap_vpp_0_1f9cda8e
+name: sky130_fd_pr__cap_vpp_03p9x03p9_m1m2_shieldl1_floatm3
 settings: {}

--- a/tests/test_components/test_pdk_settings_sky130_fd_pr__cap_vpp_04p4x04p6_l1m1m2_noshield_.yml
+++ b/tests/test_components/test_pdk_settings_sky130_fd_pr__cap_vpp_04p4x04p6_l1m1m2_noshield_.yml
@@ -1,3 +1,3 @@
 info: {}
-name: sky130_fd_pr__cap_vpp_0_dc55ede1
+name: sky130_fd_pr__cap_vpp_04p4x04p6_l1m1m2_noshield
 settings: {}

--- a/tests/test_components/test_pdk_settings_sky130_fd_pr__cap_vpp_04p4x04p6_l1m1m2_noshield_o2subcell_.yml
+++ b/tests/test_components/test_pdk_settings_sky130_fd_pr__cap_vpp_04p4x04p6_l1m1m2_noshield_o2subcell_.yml
@@ -1,3 +1,3 @@
 info: {}
-name: sky130_fd_pr__cap_vpp_0_fd5a2706
+name: sky130_fd_pr__cap_vpp_04p4x04p6_l1m1m2_noshield_o2subcell
 settings: {}

--- a/tests/test_components/test_pdk_settings_sky130_fd_pr__cap_vpp_04p4x04p6_l1m1m2_shieldpo_floatm3_.yml
+++ b/tests/test_components/test_pdk_settings_sky130_fd_pr__cap_vpp_04p4x04p6_l1m1m2_shieldpo_floatm3_.yml
@@ -1,3 +1,3 @@
 info: {}
-name: sky130_fd_pr__cap_vpp_0_fc7c28cc
+name: sky130_fd_pr__cap_vpp_04p4x04p6_l1m1m2_shieldpo_floatm3
 settings: {}

--- a/tests/test_components/test_pdk_settings_sky130_fd_pr__cap_vpp_04p4x04p6_m1m2_noshield_.yml
+++ b/tests/test_components/test_pdk_settings_sky130_fd_pr__cap_vpp_04p4x04p6_m1m2_noshield_.yml
@@ -1,3 +1,3 @@
 info: {}
-name: sky130_fd_pr__cap_vpp_0_a9721069
+name: sky130_fd_pr__cap_vpp_04p4x04p6_m1m2_noshield
 settings: {}

--- a/tests/test_components/test_pdk_settings_sky130_fd_pr__cap_vpp_04p4x04p6_m1m2_noshield_o2_.yml
+++ b/tests/test_components/test_pdk_settings_sky130_fd_pr__cap_vpp_04p4x04p6_m1m2_noshield_o2_.yml
@@ -1,3 +1,3 @@
 info: {}
-name: sky130_fd_pr__cap_vpp_0_3ef2ebd5
+name: sky130_fd_pr__cap_vpp_04p4x04p6_m1m2_noshield_o2
 settings: {}

--- a/tests/test_components/test_pdk_settings_sky130_fd_pr__cap_vpp_04p4x04p6_m1m2_shieldl1_.yml
+++ b/tests/test_components/test_pdk_settings_sky130_fd_pr__cap_vpp_04p4x04p6_m1m2_shieldl1_.yml
@@ -1,3 +1,3 @@
 info: {}
-name: sky130_fd_pr__cap_vpp_0_08d256c8
+name: sky130_fd_pr__cap_vpp_04p4x04p6_m1m2_shieldl1
 settings: {}

--- a/tests/test_components/test_pdk_settings_sky130_fd_pr__cap_vpp_04p4x04p6_m1m2m3_shieldl1_.yml
+++ b/tests/test_components/test_pdk_settings_sky130_fd_pr__cap_vpp_04p4x04p6_m1m2m3_shieldl1_.yml
@@ -1,3 +1,3 @@
 info: {}
-name: sky130_fd_pr__cap_vpp_0_2b4f0089
+name: sky130_fd_pr__cap_vpp_04p4x04p6_m1m2m3_shieldl1
 settings: {}

--- a/tests/test_components/test_pdk_settings_sky130_fd_pr__cap_vpp_04p4x04p6_m1m2m3_shieldl1m5_floatm4_.yml
+++ b/tests/test_components/test_pdk_settings_sky130_fd_pr__cap_vpp_04p4x04p6_m1m2m3_shieldl1m5_floatm4_.yml
@@ -1,3 +1,3 @@
 info: {}
-name: sky130_fd_pr__cap_vpp_0_ddeed850
+name: sky130_fd_pr__cap_vpp_04p4x04p6_m1m2m3_shieldl1m5_floatm4
 settings: {}

--- a/tests/test_components/test_pdk_settings_sky130_fd_pr__cap_vpp_04p4x04p6_m1m2m3_shieldl1m5_floatm4_top_.yml
+++ b/tests/test_components/test_pdk_settings_sky130_fd_pr__cap_vpp_04p4x04p6_m1m2m3_shieldl1m5_floatm4_top_.yml
@@ -1,3 +1,3 @@
 info: {}
-name: sky130_fd_pr__cap_vpp_0_1200b0d2
+name: sky130_fd_pr__cap_vpp_04p4x04p6_m1m2m3_shieldl1m5_floatm4_top
 settings: {}

--- a/tests/test_components/test_pdk_settings_sky130_fd_pr__cap_vpp_05p9x05p9_m1m2m3m4_shieldl1_wafflecap_.yml
+++ b/tests/test_components/test_pdk_settings_sky130_fd_pr__cap_vpp_05p9x05p9_m1m2m3m4_shieldl1_wafflecap_.yml
@@ -1,3 +1,3 @@
 info: {}
-name: sky130_fd_pr__cap_vpp_0_e200b049
+name: sky130_fd_pr__cap_vpp_05p9x05p9_m1m2m3m4_shieldl1_wafflecap
 settings: {}

--- a/tests/test_components/test_pdk_settings_sky130_fd_pr__cap_vpp_06p8x06p1_l1m1m2m3_shieldpom4_.yml
+++ b/tests/test_components/test_pdk_settings_sky130_fd_pr__cap_vpp_06p8x06p1_l1m1m2m3_shieldpom4_.yml
@@ -1,3 +1,3 @@
 info: {}
-name: sky130_fd_pr__cap_vpp_0_2156364f
+name: sky130_fd_pr__cap_vpp_06p8x06p1_l1m1m2m3_shieldpom4
 settings: {}

--- a/tests/test_components/test_pdk_settings_sky130_fd_pr__cap_vpp_06p8x06p1_l1m1m2m3_shieldpom4_top_.yml
+++ b/tests/test_components/test_pdk_settings_sky130_fd_pr__cap_vpp_06p8x06p1_l1m1m2m3_shieldpom4_top_.yml
@@ -1,3 +1,3 @@
 info: {}
-name: sky130_fd_pr__cap_vpp_0_a7cf3696
+name: sky130_fd_pr__cap_vpp_06p8x06p1_l1m1m2m3_shieldpom4_top
 settings: {}

--- a/tests/test_components/test_pdk_settings_sky130_fd_pr__cap_vpp_06p8x06p1_m1m2m3_shieldl1m4_.yml
+++ b/tests/test_components/test_pdk_settings_sky130_fd_pr__cap_vpp_06p8x06p1_m1m2m3_shieldl1m4_.yml
@@ -1,3 +1,3 @@
 info: {}
-name: sky130_fd_pr__cap_vpp_0_11b101b0
+name: sky130_fd_pr__cap_vpp_06p8x06p1_m1m2m3_shieldl1m4
 settings: {}

--- a/tests/test_components/test_pdk_settings_sky130_fd_pr__cap_vpp_06p8x06p1_m1m2m3_shieldl1m4_top_.yml
+++ b/tests/test_components/test_pdk_settings_sky130_fd_pr__cap_vpp_06p8x06p1_m1m2m3_shieldl1m4_top_.yml
@@ -1,3 +1,3 @@
 info: {}
-name: sky130_fd_pr__cap_vpp_0_639b7022
+name: sky130_fd_pr__cap_vpp_06p8x06p1_m1m2m3_shieldl1m4_top
 settings: {}

--- a/tests/test_components/test_pdk_settings_sky130_fd_pr__cap_vpp_08p6x07p8_l1m1m2_noshield_.yml
+++ b/tests/test_components/test_pdk_settings_sky130_fd_pr__cap_vpp_08p6x07p8_l1m1m2_noshield_.yml
@@ -1,3 +1,3 @@
 info: {}
-name: sky130_fd_pr__cap_vpp_0_55740a65
+name: sky130_fd_pr__cap_vpp_08p6x07p8_l1m1m2_noshield
 settings: {}

--- a/tests/test_components/test_pdk_settings_sky130_fd_pr__cap_vpp_08p6x07p8_l1m1m2_noshield_o2subcell_.yml
+++ b/tests/test_components/test_pdk_settings_sky130_fd_pr__cap_vpp_08p6x07p8_l1m1m2_noshield_o2subcell_.yml
@@ -1,3 +1,3 @@
 info: {}
-name: sky130_fd_pr__cap_vpp_0_03713532
+name: sky130_fd_pr__cap_vpp_08p6x07p8_l1m1m2_noshield_o2subcell
 settings: {}

--- a/tests/test_components/test_pdk_settings_sky130_fd_pr__cap_vpp_08p6x07p8_l1m1m2_shieldpo_floatm3_.yml
+++ b/tests/test_components/test_pdk_settings_sky130_fd_pr__cap_vpp_08p6x07p8_l1m1m2_shieldpo_floatm3_.yml
@@ -1,3 +1,3 @@
 info: {}
-name: sky130_fd_pr__cap_vpp_0_dcd434ee
+name: sky130_fd_pr__cap_vpp_08p6x07p8_l1m1m2_shieldpo_floatm3
 settings: {}

--- a/tests/test_components/test_pdk_settings_sky130_fd_pr__cap_vpp_08p6x07p8_m1m2_noshield_.yml
+++ b/tests/test_components/test_pdk_settings_sky130_fd_pr__cap_vpp_08p6x07p8_m1m2_noshield_.yml
@@ -1,3 +1,3 @@
 info: {}
-name: sky130_fd_pr__cap_vpp_0_b82ff4f2
+name: sky130_fd_pr__cap_vpp_08p6x07p8_m1m2_noshield
 settings: {}

--- a/tests/test_components/test_pdk_settings_sky130_fd_pr__cap_vpp_08p6x07p8_m1m2_shieldl1_.yml
+++ b/tests/test_components/test_pdk_settings_sky130_fd_pr__cap_vpp_08p6x07p8_m1m2_shieldl1_.yml
@@ -1,3 +1,3 @@
 info: {}
-name: sky130_fd_pr__cap_vpp_0_103143f0
+name: sky130_fd_pr__cap_vpp_08p6x07p8_m1m2_shieldl1
 settings: {}

--- a/tests/test_components/test_pdk_settings_sky130_fd_pr__cap_vpp_08p6x07p8_m1m2m3_shieldl1_.yml
+++ b/tests/test_components/test_pdk_settings_sky130_fd_pr__cap_vpp_08p6x07p8_m1m2m3_shieldl1_.yml
@@ -1,3 +1,3 @@
 info: {}
-name: sky130_fd_pr__cap_vpp_0_ae9d0a97
+name: sky130_fd_pr__cap_vpp_08p6x07p8_m1m2m3_shieldl1
 settings: {}

--- a/tests/test_components/test_pdk_settings_sky130_fd_pr__cap_vpp_08p6x07p8_m1m2m3_shieldl1m5_floatm4_.yml
+++ b/tests/test_components/test_pdk_settings_sky130_fd_pr__cap_vpp_08p6x07p8_m1m2m3_shieldl1m5_floatm4_.yml
@@ -1,3 +1,3 @@
 info: {}
-name: sky130_fd_pr__cap_vpp_0_a60ecf8d
+name: sky130_fd_pr__cap_vpp_08p6x07p8_m1m2m3_shieldl1m5_floatm4
 settings: {}

--- a/tests/test_components/test_pdk_settings_sky130_fd_pr__cap_vpp_08p6x07p8_m1m2m3_shieldl1m5_floatm4_top_.yml
+++ b/tests/test_components/test_pdk_settings_sky130_fd_pr__cap_vpp_08p6x07p8_m1m2m3_shieldl1m5_floatm4_top_.yml
@@ -1,3 +1,3 @@
 info: {}
-name: sky130_fd_pr__cap_vpp_0_6774a6cd
+name: sky130_fd_pr__cap_vpp_08p6x07p8_m1m2m3_shieldl1m5_floatm4_top
 settings: {}

--- a/tests/test_components/test_pdk_settings_sky130_fd_pr__cap_vpp_11p3x11p3_m1m2m3m4_shieldl1_wafflecap_.yml
+++ b/tests/test_components/test_pdk_settings_sky130_fd_pr__cap_vpp_11p3x11p3_m1m2m3m4_shieldl1_wafflecap_.yml
@@ -1,3 +1,3 @@
 info: {}
-name: sky130_fd_pr__cap_vpp_1_65ab9527
+name: sky130_fd_pr__cap_vpp_11p3x11p3_m1m2m3m4_shieldl1_wafflecap
 settings: {}

--- a/tests/test_components/test_pdk_settings_sky130_fd_pr__cap_vpp_11p3x11p8_l1m1m2m3m4_shieldm5_nhv_.yml
+++ b/tests/test_components/test_pdk_settings_sky130_fd_pr__cap_vpp_11p3x11p8_l1m1m2m3m4_shieldm5_nhv_.yml
@@ -1,3 +1,3 @@
 info: {}
-name: sky130_fd_pr__cap_vpp_1_c10b85e3
+name: sky130_fd_pr__cap_vpp_11p3x11p8_l1m1m2m3m4_shieldm5_nhv
 settings: {}

--- a/tests/test_components/test_pdk_settings_sky130_fd_pr__cap_vpp_11p3x11p8_l1m1m2m3m4_shieldm5_nhvtop_.yml
+++ b/tests/test_components/test_pdk_settings_sky130_fd_pr__cap_vpp_11p3x11p8_l1m1m2m3m4_shieldm5_nhvtop_.yml
@@ -1,3 +1,3 @@
 info: {}
-name: sky130_fd_pr__cap_vpp_1_38f6ad06
+name: sky130_fd_pr__cap_vpp_11p3x11p8_l1m1m2m3m4_shieldm5_nhvtop
 settings: {}

--- a/tests/test_components/test_pdk_settings_sky130_fd_pr__cap_vpp_11p5x11p7_l1m1m2_noshield_.yml
+++ b/tests/test_components/test_pdk_settings_sky130_fd_pr__cap_vpp_11p5x11p7_l1m1m2_noshield_.yml
@@ -1,3 +1,3 @@
 info: {}
-name: sky130_fd_pr__cap_vpp_1_f8c39a87
+name: sky130_fd_pr__cap_vpp_11p5x11p7_l1m1m2_noshield
 settings: {}

--- a/tests/test_components/test_pdk_settings_sky130_fd_pr__cap_vpp_11p5x11p7_l1m1m2_shieldpom3_.yml
+++ b/tests/test_components/test_pdk_settings_sky130_fd_pr__cap_vpp_11p5x11p7_l1m1m2_shieldpom3_.yml
@@ -1,3 +1,3 @@
 info: {}
-name: sky130_fd_pr__cap_vpp_1_8bce144f
+name: sky130_fd_pr__cap_vpp_11p5x11p7_l1m1m2_shieldpom3
 settings: {}

--- a/tests/test_components/test_pdk_settings_sky130_fd_pr__cap_vpp_11p5x11p7_l1m1m2m3_shieldm4_.yml
+++ b/tests/test_components/test_pdk_settings_sky130_fd_pr__cap_vpp_11p5x11p7_l1m1m2m3_shieldm4_.yml
@@ -1,3 +1,3 @@
 info: {}
-name: sky130_fd_pr__cap_vpp_1_6aed42e8
+name: sky130_fd_pr__cap_vpp_11p5x11p7_l1m1m2m3_shieldm4
 settings: {}

--- a/tests/test_components/test_pdk_settings_sky130_fd_pr__cap_vpp_11p5x11p7_l1m1m2m3_shieldm4_top_.yml
+++ b/tests/test_components/test_pdk_settings_sky130_fd_pr__cap_vpp_11p5x11p7_l1m1m2m3_shieldm4_top_.yml
@@ -1,3 +1,3 @@
 info: {}
-name: sky130_fd_pr__cap_vpp_1_198faefe
+name: sky130_fd_pr__cap_vpp_11p5x11p7_l1m1m2m3_shieldm4_top
 settings: {}

--- a/tests/test_components/test_pdk_settings_sky130_fd_pr__cap_vpp_11p5x11p7_l1m1m2m3_shieldpom4_.yml
+++ b/tests/test_components/test_pdk_settings_sky130_fd_pr__cap_vpp_11p5x11p7_l1m1m2m3_shieldpom4_.yml
@@ -1,3 +1,3 @@
 info: {}
-name: sky130_fd_pr__cap_vpp_1_26d3416d
+name: sky130_fd_pr__cap_vpp_11p5x11p7_l1m1m2m3_shieldpom4
 settings: {}

--- a/tests/test_components/test_pdk_settings_sky130_fd_pr__cap_vpp_11p5x11p7_l1m1m2m3_shieldpom4_top_.yml
+++ b/tests/test_components/test_pdk_settings_sky130_fd_pr__cap_vpp_11p5x11p7_l1m1m2m3_shieldpom4_top_.yml
@@ -1,3 +1,3 @@
 info: {}
-name: sky130_fd_pr__cap_vpp_1_3e968221
+name: sky130_fd_pr__cap_vpp_11p5x11p7_l1m1m2m3_shieldpom4_top
 settings: {}

--- a/tests/test_components/test_pdk_settings_sky130_fd_pr__cap_vpp_11p5x11p7_l1m1m2m3m4_shieldm5_.yml
+++ b/tests/test_components/test_pdk_settings_sky130_fd_pr__cap_vpp_11p5x11p7_l1m1m2m3m4_shieldm5_.yml
@@ -1,3 +1,3 @@
 info: {}
-name: sky130_fd_pr__cap_vpp_1_55f48bd9
+name: sky130_fd_pr__cap_vpp_11p5x11p7_l1m1m2m3m4_shieldm5
 settings: {}

--- a/tests/test_components/test_pdk_settings_sky130_fd_pr__cap_vpp_11p5x11p7_l1m1m2m3m4_shieldm5_top_.yml
+++ b/tests/test_components/test_pdk_settings_sky130_fd_pr__cap_vpp_11p5x11p7_l1m1m2m3m4_shieldm5_top_.yml
@@ -1,3 +1,3 @@
 info: {}
-name: sky130_fd_pr__cap_vpp_1_424d5cb3
+name: sky130_fd_pr__cap_vpp_11p5x11p7_l1m1m2m3m4_shieldm5_top
 settings: {}

--- a/tests/test_components/test_pdk_settings_sky130_fd_pr__cap_vpp_11p5x11p7_l1m1m2m3m4_shieldpom5_.yml
+++ b/tests/test_components/test_pdk_settings_sky130_fd_pr__cap_vpp_11p5x11p7_l1m1m2m3m4_shieldpom5_.yml
@@ -1,3 +1,3 @@
 info: {}
-name: sky130_fd_pr__cap_vpp_1_73ec0920
+name: sky130_fd_pr__cap_vpp_11p5x11p7_l1m1m2m3m4_shieldpom5
 settings: {}

--- a/tests/test_components/test_pdk_settings_sky130_fd_pr__cap_vpp_11p5x11p7_l1m1m2m3m4_shieldpom5_top_.yml
+++ b/tests/test_components/test_pdk_settings_sky130_fd_pr__cap_vpp_11p5x11p7_l1m1m2m3m4_shieldpom5_top_.yml
@@ -1,3 +1,3 @@
 info: {}
-name: sky130_fd_pr__cap_vpp_1_3047e520
+name: sky130_fd_pr__cap_vpp_11p5x11p7_l1m1m2m3m4_shieldpom5_top
 settings: {}

--- a/tests/test_components/test_pdk_settings_sky130_fd_pr__cap_vpp_11p5x11p7_l1m1m2m3m4_shieldpom5_x6_.yml
+++ b/tests/test_components/test_pdk_settings_sky130_fd_pr__cap_vpp_11p5x11p7_l1m1m2m3m4_shieldpom5_x6_.yml
@@ -1,3 +1,3 @@
 info: {}
-name: sky130_fd_pr__cap_vpp_1_fcae5f2e
+name: sky130_fd_pr__cap_vpp_11p5x11p7_l1m1m2m3m4_shieldpom5_x6
 settings: {}

--- a/tests/test_components/test_pdk_settings_sky130_fd_pr__cap_vpp_11p5x11p7_l1m1m2m3m4_shieldpom5_x7_.yml
+++ b/tests/test_components/test_pdk_settings_sky130_fd_pr__cap_vpp_11p5x11p7_l1m1m2m3m4_shieldpom5_x7_.yml
@@ -1,3 +1,3 @@
 info: {}
-name: sky130_fd_pr__cap_vpp_1_4f2b4672
+name: sky130_fd_pr__cap_vpp_11p5x11p7_l1m1m2m3m4_shieldpom5_x7
 settings: {}

--- a/tests/test_components/test_pdk_settings_sky130_fd_pr__cap_vpp_11p5x11p7_l1m1m2m3m4_shieldpom5_x8_.yml
+++ b/tests/test_components/test_pdk_settings_sky130_fd_pr__cap_vpp_11p5x11p7_l1m1m2m3m4_shieldpom5_x8_.yml
@@ -1,3 +1,3 @@
 info: {}
-name: sky130_fd_pr__cap_vpp_1_f62302ce
+name: sky130_fd_pr__cap_vpp_11p5x11p7_l1m1m2m3m4_shieldpom5_x8
 settings: {}

--- a/tests/test_components/test_pdk_settings_sky130_fd_pr__cap_vpp_11p5x11p7_l1m1m2m3m4_shieldpom5_x9_.yml
+++ b/tests/test_components/test_pdk_settings_sky130_fd_pr__cap_vpp_11p5x11p7_l1m1m2m3m4_shieldpom5_x9_.yml
@@ -1,3 +1,3 @@
 info: {}
-name: sky130_fd_pr__cap_vpp_1_72c3afd2
+name: sky130_fd_pr__cap_vpp_11p5x11p7_l1m1m2m3m4_shieldpom5_x9
 settings: {}

--- a/tests/test_components/test_pdk_settings_sky130_fd_pr__cap_vpp_11p5x11p7_l1m1m2m3m4_shieldpom5_x_.yml
+++ b/tests/test_components/test_pdk_settings_sky130_fd_pr__cap_vpp_11p5x11p7_l1m1m2m3m4_shieldpom5_x_.yml
@@ -1,3 +1,3 @@
 info: {}
-name: sky130_fd_pr__cap_vpp_1_5ca245be
+name: sky130_fd_pr__cap_vpp_11p5x11p7_l1m1m2m3m4_shieldpom5_x
 settings: {}

--- a/tests/test_components/test_pdk_settings_sky130_fd_pr__cap_vpp_11p5x11p7_l1m1m2m3m4_shieldpom5_xtop_.yml
+++ b/tests/test_components/test_pdk_settings_sky130_fd_pr__cap_vpp_11p5x11p7_l1m1m2m3m4_shieldpom5_xtop_.yml
@@ -1,3 +1,3 @@
 info: {}
-name: sky130_fd_pr__cap_vpp_1_a6b81b8a
+name: sky130_fd_pr__cap_vpp_11p5x11p7_l1m1m2m3m4_shieldpom5_xtop
 settings: {}

--- a/tests/test_components/test_pdk_settings_sky130_fd_pr__cap_vpp_11p5x11p7_m1m2_noshield_.yml
+++ b/tests/test_components/test_pdk_settings_sky130_fd_pr__cap_vpp_11p5x11p7_m1m2_noshield_.yml
@@ -1,3 +1,3 @@
 info: {}
-name: sky130_fd_pr__cap_vpp_1_61ffd5e1
+name: sky130_fd_pr__cap_vpp_11p5x11p7_m1m2_noshield
 settings: {}

--- a/tests/test_components/test_pdk_settings_sky130_fd_pr__cap_vpp_11p5x11p7_m1m2_shieldl1_.yml
+++ b/tests/test_components/test_pdk_settings_sky130_fd_pr__cap_vpp_11p5x11p7_m1m2_shieldl1_.yml
@@ -1,3 +1,3 @@
 info: {}
-name: sky130_fd_pr__cap_vpp_1_e3cdb200
+name: sky130_fd_pr__cap_vpp_11p5x11p7_m1m2_shieldl1
 settings: {}

--- a/tests/test_components/test_pdk_settings_sky130_fd_pr__cap_vpp_11p5x11p7_m1m2m3_shieldl1_.yml
+++ b/tests/test_components/test_pdk_settings_sky130_fd_pr__cap_vpp_11p5x11p7_m1m2m3_shieldl1_.yml
@@ -1,3 +1,3 @@
 info: {}
-name: sky130_fd_pr__cap_vpp_1_6567f70c
+name: sky130_fd_pr__cap_vpp_11p5x11p7_m1m2m3_shieldl1
 settings: {}

--- a/tests/test_components/test_pdk_settings_sky130_fd_pr__cap_vpp_11p5x11p7_m1m2m3_shieldl1m5_floatm4_.yml
+++ b/tests/test_components/test_pdk_settings_sky130_fd_pr__cap_vpp_11p5x11p7_m1m2m3_shieldl1m5_floatm4_.yml
@@ -1,3 +1,3 @@
 info: {}
-name: sky130_fd_pr__cap_vpp_1_1b75d8cc
+name: sky130_fd_pr__cap_vpp_11p5x11p7_m1m2m3_shieldl1m5_floatm4
 settings: {}

--- a/tests/test_components/test_pdk_settings_sky130_fd_pr__cap_vpp_11p5x11p7_m1m2m3_shieldl1m5_floatm4_top_.yml
+++ b/tests/test_components/test_pdk_settings_sky130_fd_pr__cap_vpp_11p5x11p7_m1m2m3_shieldl1m5_floatm4_top_.yml
@@ -1,3 +1,3 @@
 info: {}
-name: sky130_fd_pr__cap_vpp_1_c9807a69
+name: sky130_fd_pr__cap_vpp_11p5x11p7_m1m2m3_shieldl1m5_floatm4_top
 settings: {}

--- a/tests/test_components/test_pdk_settings_sky130_fd_pr__cap_vpp_11p5x11p7_m1m2m3m4_shieldl1m5_.yml
+++ b/tests/test_components/test_pdk_settings_sky130_fd_pr__cap_vpp_11p5x11p7_m1m2m3m4_shieldl1m5_.yml
@@ -1,3 +1,3 @@
 info: {}
-name: sky130_fd_pr__cap_vpp_1_fe1bcb4b
+name: sky130_fd_pr__cap_vpp_11p5x11p7_m1m2m3m4_shieldl1m5
 settings: {}

--- a/tests/test_components/test_pdk_settings_sky130_fd_pr__cap_vpp_11p5x11p7_m1m2m3m4_shieldl1m5_top_.yml
+++ b/tests/test_components/test_pdk_settings_sky130_fd_pr__cap_vpp_11p5x11p7_m1m2m3m4_shieldl1m5_top_.yml
@@ -1,3 +1,3 @@
 info: {}
-name: sky130_fd_pr__cap_vpp_1_7ba4bc0e
+name: sky130_fd_pr__cap_vpp_11p5x11p7_m1m2m3m4_shieldl1m5_top
 settings: {}

--- a/tests/test_components/test_pdk_settings_sky130_fd_pr__cap_vpp_11p5x11p7_m1m2m3m4_shieldm5_.yml
+++ b/tests/test_components/test_pdk_settings_sky130_fd_pr__cap_vpp_11p5x11p7_m1m2m3m4_shieldm5_.yml
@@ -1,3 +1,3 @@
 info: {}
-name: sky130_fd_pr__cap_vpp_1_079f76fa
+name: sky130_fd_pr__cap_vpp_11p5x11p7_m1m2m3m4_shieldm5
 settings: {}

--- a/tests/test_components/test_pdk_settings_sky130_fd_pr__cap_vpp_11p5x11p7_m1m4_noshield_.yml
+++ b/tests/test_components/test_pdk_settings_sky130_fd_pr__cap_vpp_11p5x11p7_m1m4_noshield_.yml
@@ -1,3 +1,3 @@
 info: {}
-name: sky130_fd_pr__cap_vpp_1_eb1feb6e
+name: sky130_fd_pr__cap_vpp_11p5x11p7_m1m4_noshield
 settings: {}

--- a/tests/test_components/test_pdk_settings_sky130_fd_pr__cap_vpp_11p5x11p7_pol1m1m2m3m4m5_noshield_.yml
+++ b/tests/test_components/test_pdk_settings_sky130_fd_pr__cap_vpp_11p5x11p7_pol1m1m2m3m4m5_noshield_.yml
@@ -1,3 +1,3 @@
 info: {}
-name: sky130_fd_pr__cap_vpp_1_f6865adb
+name: sky130_fd_pr__cap_vpp_11p5x11p7_pol1m1m2m3m4m5_noshield
 settings: {}

--- a/tests/test_components/test_pdk_settings_sky130_fd_pr__cap_vpp_11p5x23p1_pol1m1m2m3m4m5_noshield_.yml
+++ b/tests/test_components/test_pdk_settings_sky130_fd_pr__cap_vpp_11p5x23p1_pol1m1m2m3m4m5_noshield_.yml
@@ -1,3 +1,3 @@
 info: {}
-name: sky130_fd_pr__cap_vpp_1_b64ba4ed
+name: sky130_fd_pr__cap_vpp_11p5x23p1_pol1m1m2m3m4m5_noshield
 settings: {}

--- a/tests/test_components/test_pdk_settings_sky130_fd_pr__cap_vpp_22p5x11p7_pol1m1m2m3m4m5_noshield_.yml
+++ b/tests/test_components/test_pdk_settings_sky130_fd_pr__cap_vpp_22p5x11p7_pol1m1m2m3m4m5_noshield_.yml
@@ -1,3 +1,3 @@
 info: {}
-name: sky130_fd_pr__cap_vpp_2_eb23824e
+name: sky130_fd_pr__cap_vpp_22p5x11p7_pol1m1m2m3m4m5_noshield
 settings: {}

--- a/tests/test_components/test_pdk_settings_sky130_fd_pr__cap_vpp_22p5x23p1_pol1m1m2m3m4m5_noshield_.yml
+++ b/tests/test_components/test_pdk_settings_sky130_fd_pr__cap_vpp_22p5x23p1_pol1m1m2m3m4m5_noshield_.yml
@@ -1,3 +1,3 @@
 info: {}
-name: sky130_fd_pr__cap_vpp_2_f583679a
+name: sky130_fd_pr__cap_vpp_22p5x23p1_pol1m1m2m3m4m5_noshield
 settings: {}

--- a/tests/test_components/test_pdk_settings_sky130_fd_pr__cap_vpp_33p6x11p7_pol1m1m2m3m4m5_noshield_.yml
+++ b/tests/test_components/test_pdk_settings_sky130_fd_pr__cap_vpp_33p6x11p7_pol1m1m2m3m4m5_noshield_.yml
@@ -1,3 +1,3 @@
 info: {}
-name: sky130_fd_pr__cap_vpp_3_49038792
+name: sky130_fd_pr__cap_vpp_33p6x11p7_pol1m1m2m3m4m5_noshield
 settings: {}

--- a/tests/test_components/test_pdk_settings_sky130_fd_pr__cap_vpp_33p6x23p1_pol1m1m2m3m4m5_noshield_.yml
+++ b/tests/test_components/test_pdk_settings_sky130_fd_pr__cap_vpp_33p6x23p1_pol1m1m2m3m4m5_noshield_.yml
@@ -1,3 +1,3 @@
 info: {}
-name: sky130_fd_pr__cap_vpp_3_0677d1b3
+name: sky130_fd_pr__cap_vpp_33p6x23p1_pol1m1m2m3m4m5_noshield
 settings: {}

--- a/tests/test_components/test_pdk_settings_sky130_fd_pr__cap_vpp_44p7x11p7_pol1m1m2m3m4m5_noshield_.yml
+++ b/tests/test_components/test_pdk_settings_sky130_fd_pr__cap_vpp_44p7x11p7_pol1m1m2m3m4m5_noshield_.yml
@@ -1,3 +1,3 @@
 info: {}
-name: sky130_fd_pr__cap_vpp_4_e0460b62
+name: sky130_fd_pr__cap_vpp_44p7x11p7_pol1m1m2m3m4m5_noshield
 settings: {}

--- a/tests/test_components/test_pdk_settings_sky130_fd_pr__cap_vpp_44p7x23p1_pol1m1m2m3m4m5_noshield_.yml
+++ b/tests/test_components/test_pdk_settings_sky130_fd_pr__cap_vpp_44p7x23p1_pol1m1m2m3m4m5_noshield_.yml
@@ -1,3 +1,3 @@
 info: {}
-name: sky130_fd_pr__cap_vpp_4_f590d71d
+name: sky130_fd_pr__cap_vpp_44p7x23p1_pol1m1m2m3m4m5_noshield
 settings: {}

--- a/tests/test_components/test_pdk_settings_sky130_fd_pr__cap_vpp_55p8x11p7_pol1m1m2m3m4m5_noshield_.yml
+++ b/tests/test_components/test_pdk_settings_sky130_fd_pr__cap_vpp_55p8x11p7_pol1m1m2m3m4m5_noshield_.yml
@@ -1,3 +1,3 @@
 info: {}
-name: sky130_fd_pr__cap_vpp_5_d4fe1d6f
+name: sky130_fd_pr__cap_vpp_55p8x11p7_pol1m1m2m3m4m5_noshield
 settings: {}

--- a/tests/test_components/test_pdk_settings_sky130_fd_pr__cap_vpp_55p8x11p7_pol1m1m2m3m4m5_noshield_m5pullin_.yml
+++ b/tests/test_components/test_pdk_settings_sky130_fd_pr__cap_vpp_55p8x11p7_pol1m1m2m3m4m5_noshield_m5pullin_.yml
@@ -1,3 +1,3 @@
 info: {}
-name: sky130_fd_pr__cap_vpp_5_e973081d
+name: sky130_fd_pr__cap_vpp_55p8x11p7_pol1m1m2m3m4m5_noshield_m5pullin
 settings: {}

--- a/tests/test_components/test_pdk_settings_sky130_fd_pr__cap_vpp_55p8x23p1_pol1m1m2m3m4m5_noshield_.yml
+++ b/tests/test_components/test_pdk_settings_sky130_fd_pr__cap_vpp_55p8x23p1_pol1m1m2m3m4m5_noshield_.yml
@@ -1,3 +1,3 @@
 info: {}
-name: sky130_fd_pr__cap_vpp_5_92ab6fe7
+name: sky130_fd_pr__cap_vpp_55p8x23p1_pol1m1m2m3m4m5_noshield
 settings: {}

--- a/tests/test_components/test_pdk_settings_sky130_fd_pr__cap_vpp_55p8x23p1_pol1m1m2m3m4m5_noshield_m5pullin_.yml
+++ b/tests/test_components/test_pdk_settings_sky130_fd_pr__cap_vpp_55p8x23p1_pol1m1m2m3m4m5_noshield_m5pullin_.yml
@@ -1,3 +1,3 @@
 info: {}
-name: sky130_fd_pr__cap_vpp_5_7f8ebc3a
+name: sky130_fd_pr__cap_vpp_55p8x23p1_pol1m1m2m3m4m5_noshield_m5pullin
 settings: {}

--- a/tests/test_components/test_pdk_settings_sky130_fd_pr__cap_vpp_55p8x23p1_pol1m1m2m3m4m5_noshield_test_.yml
+++ b/tests/test_components/test_pdk_settings_sky130_fd_pr__cap_vpp_55p8x23p1_pol1m1m2m3m4m5_noshield_test_.yml
@@ -1,3 +1,3 @@
 info: {}
-name: sky130_fd_pr__cap_vpp_5_484eb063
+name: sky130_fd_pr__cap_vpp_55p8x23p1_pol1m1m2m3m4m5_noshield_test
 settings: {}

--- a/tests/test_components/test_pdk_settings_sky130_fd_pr__esd_rf_nfet_20v0_hbm_21vW60p00_.yml
+++ b/tests/test_components/test_pdk_settings_sky130_fd_pr__esd_rf_nfet_20v0_hbm_21vW60p00_.yml
@@ -1,3 +1,3 @@
 info: {}
-name: sky130_fd_pr__esd_rf_nf_6871199e
+name: sky130_fd_pr__esd_rf_nfet_20v0_hbm_21vW60p00
 settings: {}

--- a/tests/test_components/test_pdk_settings_sky130_fd_pr__esd_rf_nfet_20v0_hbm_32vW60p00_.yml
+++ b/tests/test_components/test_pdk_settings_sky130_fd_pr__esd_rf_nfet_20v0_hbm_32vW60p00_.yml
@@ -1,3 +1,3 @@
 info: {}
-name: sky130_fd_pr__esd_rf_nf_3d92955d
+name: sky130_fd_pr__esd_rf_nfet_20v0_hbm_32vW60p00
 settings: {}

--- a/tests/test_components/test_pdk_settings_sky130_fd_pr__esd_rf_nfet_20v0_iec_21vW60p00_.yml
+++ b/tests/test_components/test_pdk_settings_sky130_fd_pr__esd_rf_nfet_20v0_iec_21vW60p00_.yml
@@ -1,3 +1,3 @@
 info: {}
-name: sky130_fd_pr__esd_rf_nf_e5230709
+name: sky130_fd_pr__esd_rf_nfet_20v0_iec_21vW60p00
 settings: {}

--- a/tests/test_components/test_pdk_settings_sky130_fd_pr__esd_rf_nfet_20v0_iec_32vW60p00_.yml
+++ b/tests/test_components/test_pdk_settings_sky130_fd_pr__esd_rf_nfet_20v0_iec_32vW60p00_.yml
@@ -1,3 +1,3 @@
 info: {}
-name: sky130_fd_pr__esd_rf_nf_946ca96f
+name: sky130_fd_pr__esd_rf_nfet_20v0_iec_32vW60p00
 settings: {}

--- a/tests/test_components/test_pdk_settings_sky130_fd_pr__rf_aura_drc_flag_check_.yml
+++ b/tests/test_components/test_pdk_settings_sky130_fd_pr__rf_aura_drc_flag_check_.yml
@@ -1,3 +1,3 @@
 info: {}
-name: sky130_fd_pr__rf_aura_d_fc603cd2
+name: sky130_fd_pr__rf_aura_drc_flag_check
 settings: {}

--- a/tests/test_components/test_pdk_settings_sky130_fd_pr__rf_nfet_01v8_aM02W1p65L0p15_.yml
+++ b/tests/test_components/test_pdk_settings_sky130_fd_pr__rf_nfet_01v8_aM02W1p65L0p15_.yml
@@ -1,3 +1,3 @@
 info: {}
-name: sky130_fd_pr__rf_nfet_0_75e56352
+name: sky130_fd_pr__rf_nfet_01v8_aM02W1p65L0p15
 settings: {}

--- a/tests/test_components/test_pdk_settings_sky130_fd_pr__rf_nfet_01v8_aM02W1p65L0p18_.yml
+++ b/tests/test_components/test_pdk_settings_sky130_fd_pr__rf_nfet_01v8_aM02W1p65L0p18_.yml
@@ -1,3 +1,3 @@
 info: {}
-name: sky130_fd_pr__rf_nfet_0_1399332c
+name: sky130_fd_pr__rf_nfet_01v8_aM02W1p65L0p18
 settings: {}

--- a/tests/test_components/test_pdk_settings_sky130_fd_pr__rf_nfet_01v8_aM02W1p65L0p25_.yml
+++ b/tests/test_components/test_pdk_settings_sky130_fd_pr__rf_nfet_01v8_aM02W1p65L0p25_.yml
@@ -1,3 +1,3 @@
 info: {}
-name: sky130_fd_pr__rf_nfet_0_a0035941
+name: sky130_fd_pr__rf_nfet_01v8_aM02W1p65L0p25
 settings: {}

--- a/tests/test_components/test_pdk_settings_sky130_fd_pr__rf_nfet_01v8_aM02W3p00L0p15_.yml
+++ b/tests/test_components/test_pdk_settings_sky130_fd_pr__rf_nfet_01v8_aM02W3p00L0p15_.yml
@@ -1,3 +1,3 @@
 info: {}
-name: sky130_fd_pr__rf_nfet_0_afdeb582
+name: sky130_fd_pr__rf_nfet_01v8_aM02W3p00L0p15
 settings: {}

--- a/tests/test_components/test_pdk_settings_sky130_fd_pr__rf_nfet_01v8_aM02W3p00L0p18_.yml
+++ b/tests/test_components/test_pdk_settings_sky130_fd_pr__rf_nfet_01v8_aM02W3p00L0p18_.yml
@@ -1,3 +1,3 @@
 info: {}
-name: sky130_fd_pr__rf_nfet_0_4065068b
+name: sky130_fd_pr__rf_nfet_01v8_aM02W3p00L0p18
 settings: {}

--- a/tests/test_components/test_pdk_settings_sky130_fd_pr__rf_nfet_01v8_aM02W3p00L0p25_.yml
+++ b/tests/test_components/test_pdk_settings_sky130_fd_pr__rf_nfet_01v8_aM02W3p00L0p25_.yml
@@ -1,3 +1,3 @@
 info: {}
-name: sky130_fd_pr__rf_nfet_0_1172f3c0
+name: sky130_fd_pr__rf_nfet_01v8_aM02W3p00L0p25
 settings: {}

--- a/tests/test_components/test_pdk_settings_sky130_fd_pr__rf_nfet_01v8_aM02W5p00L0p15_.yml
+++ b/tests/test_components/test_pdk_settings_sky130_fd_pr__rf_nfet_01v8_aM02W5p00L0p15_.yml
@@ -1,3 +1,3 @@
 info: {}
-name: sky130_fd_pr__rf_nfet_0_1b87dd9a
+name: sky130_fd_pr__rf_nfet_01v8_aM02W5p00L0p15
 settings: {}

--- a/tests/test_components/test_pdk_settings_sky130_fd_pr__rf_nfet_01v8_aM02W5p00L0p18_.yml
+++ b/tests/test_components/test_pdk_settings_sky130_fd_pr__rf_nfet_01v8_aM02W5p00L0p18_.yml
@@ -1,3 +1,3 @@
 info: {}
-name: sky130_fd_pr__rf_nfet_0_aa973542
+name: sky130_fd_pr__rf_nfet_01v8_aM02W5p00L0p18
 settings: {}

--- a/tests/test_components/test_pdk_settings_sky130_fd_pr__rf_nfet_01v8_aM02W5p00L0p25_.yml
+++ b/tests/test_components/test_pdk_settings_sky130_fd_pr__rf_nfet_01v8_aM02W5p00L0p25_.yml
@@ -1,3 +1,3 @@
 info: {}
-name: sky130_fd_pr__rf_nfet_0_3f205de9
+name: sky130_fd_pr__rf_nfet_01v8_aM02W5p00L0p25
 settings: {}

--- a/tests/test_components/test_pdk_settings_sky130_fd_pr__rf_nfet_01v8_aM04W1p65L0p15_.yml
+++ b/tests/test_components/test_pdk_settings_sky130_fd_pr__rf_nfet_01v8_aM04W1p65L0p15_.yml
@@ -1,3 +1,3 @@
 info: {}
-name: sky130_fd_pr__rf_nfet_0_f7faf189
+name: sky130_fd_pr__rf_nfet_01v8_aM04W1p65L0p15
 settings: {}

--- a/tests/test_components/test_pdk_settings_sky130_fd_pr__rf_nfet_01v8_aM04W1p65L0p18_.yml
+++ b/tests/test_components/test_pdk_settings_sky130_fd_pr__rf_nfet_01v8_aM04W1p65L0p18_.yml
@@ -1,3 +1,3 @@
 info: {}
-name: sky130_fd_pr__rf_nfet_0_757cc64f
+name: sky130_fd_pr__rf_nfet_01v8_aM04W1p65L0p18
 settings: {}

--- a/tests/test_components/test_pdk_settings_sky130_fd_pr__rf_nfet_01v8_aM04W1p65L0p25_.yml
+++ b/tests/test_components/test_pdk_settings_sky130_fd_pr__rf_nfet_01v8_aM04W1p65L0p25_.yml
@@ -1,3 +1,3 @@
 info: {}
-name: sky130_fd_pr__rf_nfet_0_6ddceeea
+name: sky130_fd_pr__rf_nfet_01v8_aM04W1p65L0p25
 settings: {}

--- a/tests/test_components/test_pdk_settings_sky130_fd_pr__rf_nfet_01v8_aM04W3p00L0p15_.yml
+++ b/tests/test_components/test_pdk_settings_sky130_fd_pr__rf_nfet_01v8_aM04W3p00L0p15_.yml
@@ -1,3 +1,3 @@
 info: {}
-name: sky130_fd_pr__rf_nfet_0_9a020c52
+name: sky130_fd_pr__rf_nfet_01v8_aM04W3p00L0p15
 settings: {}

--- a/tests/test_components/test_pdk_settings_sky130_fd_pr__rf_nfet_01v8_aM04W3p00L0p18_.yml
+++ b/tests/test_components/test_pdk_settings_sky130_fd_pr__rf_nfet_01v8_aM04W3p00L0p18_.yml
@@ -1,3 +1,3 @@
 info: {}
-name: sky130_fd_pr__rf_nfet_0_28e91f26
+name: sky130_fd_pr__rf_nfet_01v8_aM04W3p00L0p18
 settings: {}

--- a/tests/test_components/test_pdk_settings_sky130_fd_pr__rf_nfet_01v8_aM04W3p00L0p25_.yml
+++ b/tests/test_components/test_pdk_settings_sky130_fd_pr__rf_nfet_01v8_aM04W3p00L0p25_.yml
@@ -1,3 +1,3 @@
 info: {}
-name: sky130_fd_pr__rf_nfet_0_0999ff83
+name: sky130_fd_pr__rf_nfet_01v8_aM04W3p00L0p25
 settings: {}

--- a/tests/test_components/test_pdk_settings_sky130_fd_pr__rf_nfet_01v8_aM04W5p00L0p15_.yml
+++ b/tests/test_components/test_pdk_settings_sky130_fd_pr__rf_nfet_01v8_aM04W5p00L0p15_.yml
@@ -1,3 +1,3 @@
 info: {}
-name: sky130_fd_pr__rf_nfet_0_e5e214b1
+name: sky130_fd_pr__rf_nfet_01v8_aM04W5p00L0p15
 settings: {}

--- a/tests/test_components/test_pdk_settings_sky130_fd_pr__rf_nfet_01v8_aM04W5p00L0p18_.yml
+++ b/tests/test_components/test_pdk_settings_sky130_fd_pr__rf_nfet_01v8_aM04W5p00L0p18_.yml
@@ -1,3 +1,3 @@
 info: {}
-name: sky130_fd_pr__rf_nfet_0_78b52e7b
+name: sky130_fd_pr__rf_nfet_01v8_aM04W5p00L0p18
 settings: {}

--- a/tests/test_components/test_pdk_settings_sky130_fd_pr__rf_nfet_01v8_aM04W5p00L0p25_.yml
+++ b/tests/test_components/test_pdk_settings_sky130_fd_pr__rf_nfet_01v8_aM04W5p00L0p25_.yml
@@ -1,3 +1,3 @@
 info: {}
-name: sky130_fd_pr__rf_nfet_0_8287a837
+name: sky130_fd_pr__rf_nfet_01v8_aM04W5p00L0p25
 settings: {}

--- a/tests/test_components/test_pdk_settings_sky130_fd_pr__rf_nfet_01v8_bM02W1p65L0p15_.yml
+++ b/tests/test_components/test_pdk_settings_sky130_fd_pr__rf_nfet_01v8_bM02W1p65L0p15_.yml
@@ -1,3 +1,3 @@
 info: {}
-name: sky130_fd_pr__rf_nfet_0_dc6cc3eb
+name: sky130_fd_pr__rf_nfet_01v8_bM02W1p65L0p15
 settings: {}

--- a/tests/test_components/test_pdk_settings_sky130_fd_pr__rf_nfet_01v8_bM02W1p65L0p18_.yml
+++ b/tests/test_components/test_pdk_settings_sky130_fd_pr__rf_nfet_01v8_bM02W1p65L0p18_.yml
@@ -1,3 +1,3 @@
 info: {}
-name: sky130_fd_pr__rf_nfet_0_f5626eef
+name: sky130_fd_pr__rf_nfet_01v8_bM02W1p65L0p18
 settings: {}

--- a/tests/test_components/test_pdk_settings_sky130_fd_pr__rf_nfet_01v8_bM02W1p65L0p25_.yml
+++ b/tests/test_components/test_pdk_settings_sky130_fd_pr__rf_nfet_01v8_bM02W1p65L0p25_.yml
@@ -1,3 +1,3 @@
 info: {}
-name: sky130_fd_pr__rf_nfet_0_da48d27b
+name: sky130_fd_pr__rf_nfet_01v8_bM02W1p65L0p25
 settings: {}

--- a/tests/test_components/test_pdk_settings_sky130_fd_pr__rf_nfet_01v8_bM02W3p00L0p15_.yml
+++ b/tests/test_components/test_pdk_settings_sky130_fd_pr__rf_nfet_01v8_bM02W3p00L0p15_.yml
@@ -1,3 +1,3 @@
 info: {}
-name: sky130_fd_pr__rf_nfet_0_6e168446
+name: sky130_fd_pr__rf_nfet_01v8_bM02W3p00L0p15
 settings: {}

--- a/tests/test_components/test_pdk_settings_sky130_fd_pr__rf_nfet_01v8_bM02W3p00L0p18_.yml
+++ b/tests/test_components/test_pdk_settings_sky130_fd_pr__rf_nfet_01v8_bM02W3p00L0p18_.yml
@@ -1,3 +1,3 @@
 info: {}
-name: sky130_fd_pr__rf_nfet_0_61e8be9e
+name: sky130_fd_pr__rf_nfet_01v8_bM02W3p00L0p18
 settings: {}

--- a/tests/test_components/test_pdk_settings_sky130_fd_pr__rf_nfet_01v8_bM02W3p00L0p25_.yml
+++ b/tests/test_components/test_pdk_settings_sky130_fd_pr__rf_nfet_01v8_bM02W3p00L0p25_.yml
@@ -1,3 +1,3 @@
 info: {}
-name: sky130_fd_pr__rf_nfet_0_a60ee8d0
+name: sky130_fd_pr__rf_nfet_01v8_bM02W3p00L0p25
 settings: {}

--- a/tests/test_components/test_pdk_settings_sky130_fd_pr__rf_nfet_01v8_bM02W5p00L0p15_.yml
+++ b/tests/test_components/test_pdk_settings_sky130_fd_pr__rf_nfet_01v8_bM02W5p00L0p15_.yml
@@ -1,3 +1,3 @@
 info: {}
-name: sky130_fd_pr__rf_nfet_0_d0902223
+name: sky130_fd_pr__rf_nfet_01v8_bM02W5p00L0p15
 settings: {}

--- a/tests/test_components/test_pdk_settings_sky130_fd_pr__rf_nfet_01v8_bM02W5p00L0p18_.yml
+++ b/tests/test_components/test_pdk_settings_sky130_fd_pr__rf_nfet_01v8_bM02W5p00L0p18_.yml
@@ -1,3 +1,3 @@
 info: {}
-name: sky130_fd_pr__rf_nfet_0_f21eb3fc
+name: sky130_fd_pr__rf_nfet_01v8_bM02W5p00L0p18
 settings: {}

--- a/tests/test_components/test_pdk_settings_sky130_fd_pr__rf_nfet_01v8_bM02W5p00L0p25_.yml
+++ b/tests/test_components/test_pdk_settings_sky130_fd_pr__rf_nfet_01v8_bM02W5p00L0p25_.yml
@@ -1,3 +1,3 @@
 info: {}
-name: sky130_fd_pr__rf_nfet_0_1bc24e94
+name: sky130_fd_pr__rf_nfet_01v8_bM02W5p00L0p25
 settings: {}

--- a/tests/test_components/test_pdk_settings_sky130_fd_pr__rf_nfet_01v8_bM04W1p65L0p15_.yml
+++ b/tests/test_components/test_pdk_settings_sky130_fd_pr__rf_nfet_01v8_bM04W1p65L0p15_.yml
@@ -1,3 +1,3 @@
 info: {}
-name: sky130_fd_pr__rf_nfet_0_925001ef
+name: sky130_fd_pr__rf_nfet_01v8_bM04W1p65L0p15
 settings: {}

--- a/tests/test_components/test_pdk_settings_sky130_fd_pr__rf_nfet_01v8_bM04W1p65L0p18_.yml
+++ b/tests/test_components/test_pdk_settings_sky130_fd_pr__rf_nfet_01v8_bM04W1p65L0p18_.yml
@@ -1,3 +1,3 @@
 info: {}
-name: sky130_fd_pr__rf_nfet_0_3f9cca20
+name: sky130_fd_pr__rf_nfet_01v8_bM04W1p65L0p18
 settings: {}

--- a/tests/test_components/test_pdk_settings_sky130_fd_pr__rf_nfet_01v8_bM04W1p65L0p25_.yml
+++ b/tests/test_components/test_pdk_settings_sky130_fd_pr__rf_nfet_01v8_bM04W1p65L0p25_.yml
@@ -1,3 +1,3 @@
 info: {}
-name: sky130_fd_pr__rf_nfet_0_6ca72cf9
+name: sky130_fd_pr__rf_nfet_01v8_bM04W1p65L0p25
 settings: {}

--- a/tests/test_components/test_pdk_settings_sky130_fd_pr__rf_nfet_01v8_bM04W3p00L0p15_.yml
+++ b/tests/test_components/test_pdk_settings_sky130_fd_pr__rf_nfet_01v8_bM04W3p00L0p15_.yml
@@ -1,3 +1,3 @@
 info: {}
-name: sky130_fd_pr__rf_nfet_0_3a6b002d
+name: sky130_fd_pr__rf_nfet_01v8_bM04W3p00L0p15
 settings: {}

--- a/tests/test_components/test_pdk_settings_sky130_fd_pr__rf_nfet_01v8_bM04W3p00L0p18_.yml
+++ b/tests/test_components/test_pdk_settings_sky130_fd_pr__rf_nfet_01v8_bM04W3p00L0p18_.yml
@@ -1,3 +1,3 @@
 info: {}
-name: sky130_fd_pr__rf_nfet_0_6f612220
+name: sky130_fd_pr__rf_nfet_01v8_bM04W3p00L0p18
 settings: {}

--- a/tests/test_components/test_pdk_settings_sky130_fd_pr__rf_nfet_01v8_bM04W3p00L0p25_.yml
+++ b/tests/test_components/test_pdk_settings_sky130_fd_pr__rf_nfet_01v8_bM04W3p00L0p25_.yml
@@ -1,3 +1,3 @@
 info: {}
-name: sky130_fd_pr__rf_nfet_0_cb9b935d
+name: sky130_fd_pr__rf_nfet_01v8_bM04W3p00L0p25
 settings: {}

--- a/tests/test_components/test_pdk_settings_sky130_fd_pr__rf_nfet_01v8_bM04W5p00L0p15_.yml
+++ b/tests/test_components/test_pdk_settings_sky130_fd_pr__rf_nfet_01v8_bM04W5p00L0p15_.yml
@@ -1,3 +1,3 @@
 info: {}
-name: sky130_fd_pr__rf_nfet_0_b334e871
+name: sky130_fd_pr__rf_nfet_01v8_bM04W5p00L0p15
 settings: {}

--- a/tests/test_components/test_pdk_settings_sky130_fd_pr__rf_nfet_01v8_bM04W5p00L0p18_.yml
+++ b/tests/test_components/test_pdk_settings_sky130_fd_pr__rf_nfet_01v8_bM04W5p00L0p18_.yml
@@ -1,3 +1,3 @@
 info: {}
-name: sky130_fd_pr__rf_nfet_0_d357c545
+name: sky130_fd_pr__rf_nfet_01v8_bM04W5p00L0p18
 settings: {}

--- a/tests/test_components/test_pdk_settings_sky130_fd_pr__rf_nfet_01v8_bM04W5p00L0p25_.yml
+++ b/tests/test_components/test_pdk_settings_sky130_fd_pr__rf_nfet_01v8_bM04W5p00L0p25_.yml
@@ -1,3 +1,3 @@
 info: {}
-name: sky130_fd_pr__rf_nfet_0_902a9001
+name: sky130_fd_pr__rf_nfet_01v8_bM04W5p00L0p25
 settings: {}

--- a/tests/test_components/test_pdk_settings_sky130_fd_pr__rf_nfet_01v8_hcM04W3p00L0p15_.yml
+++ b/tests/test_components/test_pdk_settings_sky130_fd_pr__rf_nfet_01v8_hcM04W3p00L0p15_.yml
@@ -1,3 +1,3 @@
 info: {}
-name: sky130_fd_pr__rf_nfet_0_cdf6e89d
+name: sky130_fd_pr__rf_nfet_01v8_hcM04W3p00L0p15
 settings: {}

--- a/tests/test_components/test_pdk_settings_sky130_fd_pr__rf_nfet_01v8_hcM04W5p00L0p15_.yml
+++ b/tests/test_components/test_pdk_settings_sky130_fd_pr__rf_nfet_01v8_hcM04W5p00L0p15_.yml
@@ -1,3 +1,3 @@
 info: {}
-name: sky130_fd_pr__rf_nfet_0_54e25520
+name: sky130_fd_pr__rf_nfet_01v8_hcM04W5p00L0p15
 settings: {}

--- a/tests/test_components/test_pdk_settings_sky130_fd_pr__rf_nfet_01v8_lvt_aF02W0p42L0p15_.yml
+++ b/tests/test_components/test_pdk_settings_sky130_fd_pr__rf_nfet_01v8_lvt_aF02W0p42L0p15_.yml
@@ -1,3 +1,3 @@
 info: {}
-name: sky130_fd_pr__rf_nfet_0_bacca68f
+name: sky130_fd_pr__rf_nfet_01v8_lvt_aF02W0p42L0p15
 settings: {}

--- a/tests/test_components/test_pdk_settings_sky130_fd_pr__rf_nfet_01v8_lvt_aF02W0p84L0p15_.yml
+++ b/tests/test_components/test_pdk_settings_sky130_fd_pr__rf_nfet_01v8_lvt_aF02W0p84L0p15_.yml
@@ -1,3 +1,3 @@
 info: {}
-name: sky130_fd_pr__rf_nfet_0_8fa39150
+name: sky130_fd_pr__rf_nfet_01v8_lvt_aF02W0p84L0p15
 settings: {}

--- a/tests/test_components/test_pdk_settings_sky130_fd_pr__rf_nfet_01v8_lvt_aF02W1p65L0p15_.yml
+++ b/tests/test_components/test_pdk_settings_sky130_fd_pr__rf_nfet_01v8_lvt_aF02W1p65L0p15_.yml
@@ -1,3 +1,3 @@
 info: {}
-name: sky130_fd_pr__rf_nfet_0_5c698751
+name: sky130_fd_pr__rf_nfet_01v8_lvt_aF02W1p65L0p15
 settings: {}

--- a/tests/test_components/test_pdk_settings_sky130_fd_pr__rf_nfet_01v8_lvt_aF02W3p00L0p15_.yml
+++ b/tests/test_components/test_pdk_settings_sky130_fd_pr__rf_nfet_01v8_lvt_aF02W3p00L0p15_.yml
@@ -1,3 +1,3 @@
 info: {}
-name: sky130_fd_pr__rf_nfet_0_1cbbabc2
+name: sky130_fd_pr__rf_nfet_01v8_lvt_aF02W3p00L0p15
 settings: {}

--- a/tests/test_components/test_pdk_settings_sky130_fd_pr__rf_nfet_01v8_lvt_aF04W0p42L0p15_.yml
+++ b/tests/test_components/test_pdk_settings_sky130_fd_pr__rf_nfet_01v8_lvt_aF04W0p42L0p15_.yml
@@ -1,3 +1,3 @@
 info: {}
-name: sky130_fd_pr__rf_nfet_0_cf682a7b
+name: sky130_fd_pr__rf_nfet_01v8_lvt_aF04W0p42L0p15
 settings: {}

--- a/tests/test_components/test_pdk_settings_sky130_fd_pr__rf_nfet_01v8_lvt_aF04W0p84L0p15_.yml
+++ b/tests/test_components/test_pdk_settings_sky130_fd_pr__rf_nfet_01v8_lvt_aF04W0p84L0p15_.yml
@@ -1,3 +1,3 @@
 info: {}
-name: sky130_fd_pr__rf_nfet_0_5e6e2004
+name: sky130_fd_pr__rf_nfet_01v8_lvt_aF04W0p84L0p15
 settings: {}

--- a/tests/test_components/test_pdk_settings_sky130_fd_pr__rf_nfet_01v8_lvt_aF04W1p65L0p15_.yml
+++ b/tests/test_components/test_pdk_settings_sky130_fd_pr__rf_nfet_01v8_lvt_aF04W1p65L0p15_.yml
@@ -1,3 +1,3 @@
 info: {}
-name: sky130_fd_pr__rf_nfet_0_7bee77df
+name: sky130_fd_pr__rf_nfet_01v8_lvt_aF04W1p65L0p15
 settings: {}

--- a/tests/test_components/test_pdk_settings_sky130_fd_pr__rf_nfet_01v8_lvt_aF04W3p00L0p15_.yml
+++ b/tests/test_components/test_pdk_settings_sky130_fd_pr__rf_nfet_01v8_lvt_aF04W3p00L0p15_.yml
@@ -1,3 +1,3 @@
 info: {}
-name: sky130_fd_pr__rf_nfet_0_efac3702
+name: sky130_fd_pr__rf_nfet_01v8_lvt_aF04W3p00L0p15
 settings: {}

--- a/tests/test_components/test_pdk_settings_sky130_fd_pr__rf_nfet_01v8_lvt_aF06W0p42L0p15_.yml
+++ b/tests/test_components/test_pdk_settings_sky130_fd_pr__rf_nfet_01v8_lvt_aF06W0p42L0p15_.yml
@@ -1,3 +1,3 @@
 info: {}
-name: sky130_fd_pr__rf_nfet_0_1c985df6
+name: sky130_fd_pr__rf_nfet_01v8_lvt_aF06W0p42L0p15
 settings: {}

--- a/tests/test_components/test_pdk_settings_sky130_fd_pr__rf_nfet_01v8_lvt_aF06W0p84L0p15_.yml
+++ b/tests/test_components/test_pdk_settings_sky130_fd_pr__rf_nfet_01v8_lvt_aF06W0p84L0p15_.yml
@@ -1,3 +1,3 @@
 info: {}
-name: sky130_fd_pr__rf_nfet_0_7a500502
+name: sky130_fd_pr__rf_nfet_01v8_lvt_aF06W0p84L0p15
 settings: {}

--- a/tests/test_components/test_pdk_settings_sky130_fd_pr__rf_nfet_01v8_lvt_aF06W1p65L0p15_.yml
+++ b/tests/test_components/test_pdk_settings_sky130_fd_pr__rf_nfet_01v8_lvt_aF06W1p65L0p15_.yml
@@ -1,3 +1,3 @@
 info: {}
-name: sky130_fd_pr__rf_nfet_0_19293567
+name: sky130_fd_pr__rf_nfet_01v8_lvt_aF06W1p65L0p15
 settings: {}

--- a/tests/test_components/test_pdk_settings_sky130_fd_pr__rf_nfet_01v8_lvt_aF06W3p00L0p15_.yml
+++ b/tests/test_components/test_pdk_settings_sky130_fd_pr__rf_nfet_01v8_lvt_aF06W3p00L0p15_.yml
@@ -1,3 +1,3 @@
 info: {}
-name: sky130_fd_pr__rf_nfet_0_16d61624
+name: sky130_fd_pr__rf_nfet_01v8_lvt_aF06W3p00L0p15
 settings: {}

--- a/tests/test_components/test_pdk_settings_sky130_fd_pr__rf_nfet_01v8_lvt_aF08W0p42L0p15_.yml
+++ b/tests/test_components/test_pdk_settings_sky130_fd_pr__rf_nfet_01v8_lvt_aF08W0p42L0p15_.yml
@@ -1,3 +1,3 @@
 info: {}
-name: sky130_fd_pr__rf_nfet_0_3eef2ac2
+name: sky130_fd_pr__rf_nfet_01v8_lvt_aF08W0p42L0p15
 settings: {}

--- a/tests/test_components/test_pdk_settings_sky130_fd_pr__rf_nfet_01v8_lvt_aF08W0p84L0p15_.yml
+++ b/tests/test_components/test_pdk_settings_sky130_fd_pr__rf_nfet_01v8_lvt_aF08W0p84L0p15_.yml
@@ -1,3 +1,3 @@
 info: {}
-name: sky130_fd_pr__rf_nfet_0_2492b333
+name: sky130_fd_pr__rf_nfet_01v8_lvt_aF08W0p84L0p15
 settings: {}

--- a/tests/test_components/test_pdk_settings_sky130_fd_pr__rf_nfet_01v8_lvt_aF08W1p65L0p15_.yml
+++ b/tests/test_components/test_pdk_settings_sky130_fd_pr__rf_nfet_01v8_lvt_aF08W1p65L0p15_.yml
@@ -1,3 +1,3 @@
 info: {}
-name: sky130_fd_pr__rf_nfet_0_37649226
+name: sky130_fd_pr__rf_nfet_01v8_lvt_aF08W1p65L0p15
 settings: {}

--- a/tests/test_components/test_pdk_settings_sky130_fd_pr__rf_nfet_01v8_lvt_aF08W3p00L0p15_.yml
+++ b/tests/test_components/test_pdk_settings_sky130_fd_pr__rf_nfet_01v8_lvt_aF08W3p00L0p15_.yml
@@ -1,3 +1,3 @@
 info: {}
-name: sky130_fd_pr__rf_nfet_0_885e7865
+name: sky130_fd_pr__rf_nfet_01v8_lvt_aF08W3p00L0p15
 settings: {}

--- a/tests/test_components/test_pdk_settings_sky130_fd_pr__rf_nfet_01v8_lvt_aM02W1p65L0p15_.yml
+++ b/tests/test_components/test_pdk_settings_sky130_fd_pr__rf_nfet_01v8_lvt_aM02W1p65L0p15_.yml
@@ -1,3 +1,3 @@
 info: {}
-name: sky130_fd_pr__rf_nfet_0_769ed420
+name: sky130_fd_pr__rf_nfet_01v8_lvt_aM02W1p65L0p15
 settings: {}

--- a/tests/test_components/test_pdk_settings_sky130_fd_pr__rf_nfet_01v8_lvt_aM02W1p65L0p18_.yml
+++ b/tests/test_components/test_pdk_settings_sky130_fd_pr__rf_nfet_01v8_lvt_aM02W1p65L0p18_.yml
@@ -1,3 +1,3 @@
 info: {}
-name: sky130_fd_pr__rf_nfet_0_db4449c2
+name: sky130_fd_pr__rf_nfet_01v8_lvt_aM02W1p65L0p18
 settings: {}

--- a/tests/test_components/test_pdk_settings_sky130_fd_pr__rf_nfet_01v8_lvt_aM02W1p65L0p25_.yml
+++ b/tests/test_components/test_pdk_settings_sky130_fd_pr__rf_nfet_01v8_lvt_aM02W1p65L0p25_.yml
@@ -1,3 +1,3 @@
 info: {}
-name: sky130_fd_pr__rf_nfet_0_877be426
+name: sky130_fd_pr__rf_nfet_01v8_lvt_aM02W1p65L0p25
 settings: {}

--- a/tests/test_components/test_pdk_settings_sky130_fd_pr__rf_nfet_01v8_lvt_aM02W3p00L0p15_.yml
+++ b/tests/test_components/test_pdk_settings_sky130_fd_pr__rf_nfet_01v8_lvt_aM02W3p00L0p15_.yml
@@ -1,3 +1,3 @@
 info: {}
-name: sky130_fd_pr__rf_nfet_0_28db7b10
+name: sky130_fd_pr__rf_nfet_01v8_lvt_aM02W3p00L0p15
 settings: {}

--- a/tests/test_components/test_pdk_settings_sky130_fd_pr__rf_nfet_01v8_lvt_aM02W3p00L0p18_.yml
+++ b/tests/test_components/test_pdk_settings_sky130_fd_pr__rf_nfet_01v8_lvt_aM02W3p00L0p18_.yml
@@ -1,3 +1,3 @@
 info: {}
-name: sky130_fd_pr__rf_nfet_0_41ed12bb
+name: sky130_fd_pr__rf_nfet_01v8_lvt_aM02W3p00L0p18
 settings: {}

--- a/tests/test_components/test_pdk_settings_sky130_fd_pr__rf_nfet_01v8_lvt_aM02W3p00L0p25_.yml
+++ b/tests/test_components/test_pdk_settings_sky130_fd_pr__rf_nfet_01v8_lvt_aM02W3p00L0p25_.yml
@@ -1,3 +1,3 @@
 info: {}
-name: sky130_fd_pr__rf_nfet_0_5fd09673
+name: sky130_fd_pr__rf_nfet_01v8_lvt_aM02W3p00L0p25
 settings: {}

--- a/tests/test_components/test_pdk_settings_sky130_fd_pr__rf_nfet_01v8_lvt_aM02W5p00L0p15_.yml
+++ b/tests/test_components/test_pdk_settings_sky130_fd_pr__rf_nfet_01v8_lvt_aM02W5p00L0p15_.yml
@@ -1,3 +1,3 @@
 info: {}
-name: sky130_fd_pr__rf_nfet_0_c9817fec
+name: sky130_fd_pr__rf_nfet_01v8_lvt_aM02W5p00L0p15
 settings: {}

--- a/tests/test_components/test_pdk_settings_sky130_fd_pr__rf_nfet_01v8_lvt_aM02W5p00L0p18_.yml
+++ b/tests/test_components/test_pdk_settings_sky130_fd_pr__rf_nfet_01v8_lvt_aM02W5p00L0p18_.yml
@@ -1,3 +1,3 @@
 info: {}
-name: sky130_fd_pr__rf_nfet_0_f78f95c3
+name: sky130_fd_pr__rf_nfet_01v8_lvt_aM02W5p00L0p18
 settings: {}

--- a/tests/test_components/test_pdk_settings_sky130_fd_pr__rf_nfet_01v8_lvt_aM02W5p00L0p25_.yml
+++ b/tests/test_components/test_pdk_settings_sky130_fd_pr__rf_nfet_01v8_lvt_aM02W5p00L0p25_.yml
@@ -1,3 +1,3 @@
 info: {}
-name: sky130_fd_pr__rf_nfet_0_262eaa03
+name: sky130_fd_pr__rf_nfet_01v8_lvt_aM02W5p00L0p25
 settings: {}

--- a/tests/test_components/test_pdk_settings_sky130_fd_pr__rf_nfet_01v8_lvt_aM04W1p65L0p15_.yml
+++ b/tests/test_components/test_pdk_settings_sky130_fd_pr__rf_nfet_01v8_lvt_aM04W1p65L0p15_.yml
@@ -1,3 +1,3 @@
 info: {}
-name: sky130_fd_pr__rf_nfet_0_b5c98f5c
+name: sky130_fd_pr__rf_nfet_01v8_lvt_aM04W1p65L0p15
 settings: {}

--- a/tests/test_components/test_pdk_settings_sky130_fd_pr__rf_nfet_01v8_lvt_aM04W1p65L0p18_.yml
+++ b/tests/test_components/test_pdk_settings_sky130_fd_pr__rf_nfet_01v8_lvt_aM04W1p65L0p18_.yml
@@ -1,3 +1,3 @@
 info: {}
-name: sky130_fd_pr__rf_nfet_0_37c7c910
+name: sky130_fd_pr__rf_nfet_01v8_lvt_aM04W1p65L0p18
 settings: {}

--- a/tests/test_components/test_pdk_settings_sky130_fd_pr__rf_nfet_01v8_lvt_aM04W1p65L0p25_.yml
+++ b/tests/test_components/test_pdk_settings_sky130_fd_pr__rf_nfet_01v8_lvt_aM04W1p65L0p25_.yml
@@ -1,3 +1,3 @@
 info: {}
-name: sky130_fd_pr__rf_nfet_0_24616d13
+name: sky130_fd_pr__rf_nfet_01v8_lvt_aM04W1p65L0p25
 settings: {}

--- a/tests/test_components/test_pdk_settings_sky130_fd_pr__rf_nfet_01v8_lvt_aM04W3p00L0p15_.yml
+++ b/tests/test_components/test_pdk_settings_sky130_fd_pr__rf_nfet_01v8_lvt_aM04W3p00L0p15_.yml
@@ -1,3 +1,3 @@
 info: {}
-name: sky130_fd_pr__rf_nfet_0_89d99ce5
+name: sky130_fd_pr__rf_nfet_01v8_lvt_aM04W3p00L0p15
 settings: {}

--- a/tests/test_components/test_pdk_settings_sky130_fd_pr__rf_nfet_01v8_lvt_aM04W3p00L0p18_.yml
+++ b/tests/test_components/test_pdk_settings_sky130_fd_pr__rf_nfet_01v8_lvt_aM04W3p00L0p18_.yml
@@ -1,3 +1,3 @@
 info: {}
-name: sky130_fd_pr__rf_nfet_0_bb85ea93
+name: sky130_fd_pr__rf_nfet_01v8_lvt_aM04W3p00L0p18
 settings: {}

--- a/tests/test_components/test_pdk_settings_sky130_fd_pr__rf_nfet_01v8_lvt_aM04W3p00L0p25_.yml
+++ b/tests/test_components/test_pdk_settings_sky130_fd_pr__rf_nfet_01v8_lvt_aM04W3p00L0p25_.yml
@@ -1,3 +1,3 @@
 info: {}
-name: sky130_fd_pr__rf_nfet_0_69af38a0
+name: sky130_fd_pr__rf_nfet_01v8_lvt_aM04W3p00L0p25
 settings: {}

--- a/tests/test_components/test_pdk_settings_sky130_fd_pr__rf_nfet_01v8_lvt_aM04W5p00L0p15_.yml
+++ b/tests/test_components/test_pdk_settings_sky130_fd_pr__rf_nfet_01v8_lvt_aM04W5p00L0p15_.yml
@@ -1,3 +1,3 @@
 info: {}
-name: sky130_fd_pr__rf_nfet_0_80909e3a
+name: sky130_fd_pr__rf_nfet_01v8_lvt_aM04W5p00L0p15
 settings: {}

--- a/tests/test_components/test_pdk_settings_sky130_fd_pr__rf_nfet_01v8_lvt_aM04W5p00L0p18_.yml
+++ b/tests/test_components/test_pdk_settings_sky130_fd_pr__rf_nfet_01v8_lvt_aM04W5p00L0p18_.yml
@@ -1,3 +1,3 @@
 info: {}
-name: sky130_fd_pr__rf_nfet_0_23a84c2c
+name: sky130_fd_pr__rf_nfet_01v8_lvt_aM04W5p00L0p18
 settings: {}

--- a/tests/test_components/test_pdk_settings_sky130_fd_pr__rf_nfet_01v8_lvt_aM04W5p00L0p25_.yml
+++ b/tests/test_components/test_pdk_settings_sky130_fd_pr__rf_nfet_01v8_lvt_aM04W5p00L0p25_.yml
@@ -1,3 +1,3 @@
 info: {}
-name: sky130_fd_pr__rf_nfet_0_a270b242
+name: sky130_fd_pr__rf_nfet_01v8_lvt_aM04W5p00L0p25
 settings: {}

--- a/tests/test_components/test_pdk_settings_sky130_fd_pr__rf_nfet_01v8_lvt_bM02W1p65L0p15_.yml
+++ b/tests/test_components/test_pdk_settings_sky130_fd_pr__rf_nfet_01v8_lvt_bM02W1p65L0p15_.yml
@@ -1,3 +1,3 @@
 info: {}
-name: sky130_fd_pr__rf_nfet_0_67ee5a25
+name: sky130_fd_pr__rf_nfet_01v8_lvt_bM02W1p65L0p15
 settings: {}

--- a/tests/test_components/test_pdk_settings_sky130_fd_pr__rf_nfet_01v8_lvt_bM02W1p65L0p18_.yml
+++ b/tests/test_components/test_pdk_settings_sky130_fd_pr__rf_nfet_01v8_lvt_bM02W1p65L0p18_.yml
@@ -1,3 +1,3 @@
 info: {}
-name: sky130_fd_pr__rf_nfet_0_dbfad547
+name: sky130_fd_pr__rf_nfet_01v8_lvt_bM02W1p65L0p18
 settings: {}

--- a/tests/test_components/test_pdk_settings_sky130_fd_pr__rf_nfet_01v8_lvt_bM02W1p65L0p25_.yml
+++ b/tests/test_components/test_pdk_settings_sky130_fd_pr__rf_nfet_01v8_lvt_bM02W1p65L0p25_.yml
@@ -1,3 +1,3 @@
 info: {}
-name: sky130_fd_pr__rf_nfet_0_6a05cce0
+name: sky130_fd_pr__rf_nfet_01v8_lvt_bM02W1p65L0p25
 settings: {}

--- a/tests/test_components/test_pdk_settings_sky130_fd_pr__rf_nfet_01v8_lvt_bM02W3p00L0p15_.yml
+++ b/tests/test_components/test_pdk_settings_sky130_fd_pr__rf_nfet_01v8_lvt_bM02W3p00L0p15_.yml
@@ -1,3 +1,3 @@
 info: {}
-name: sky130_fd_pr__rf_nfet_0_10467abf
+name: sky130_fd_pr__rf_nfet_01v8_lvt_bM02W3p00L0p15
 settings: {}

--- a/tests/test_components/test_pdk_settings_sky130_fd_pr__rf_nfet_01v8_lvt_bM02W3p00L0p18_.yml
+++ b/tests/test_components/test_pdk_settings_sky130_fd_pr__rf_nfet_01v8_lvt_bM02W3p00L0p18_.yml
@@ -1,3 +1,3 @@
 info: {}
-name: sky130_fd_pr__rf_nfet_0_393a48b5
+name: sky130_fd_pr__rf_nfet_01v8_lvt_bM02W3p00L0p18
 settings: {}

--- a/tests/test_components/test_pdk_settings_sky130_fd_pr__rf_nfet_01v8_lvt_bM02W3p00L0p25_.yml
+++ b/tests/test_components/test_pdk_settings_sky130_fd_pr__rf_nfet_01v8_lvt_bM02W3p00L0p25_.yml
@@ -1,3 +1,3 @@
 info: {}
-name: sky130_fd_pr__rf_nfet_0_7248fecb
+name: sky130_fd_pr__rf_nfet_01v8_lvt_bM02W3p00L0p25
 settings: {}

--- a/tests/test_components/test_pdk_settings_sky130_fd_pr__rf_nfet_01v8_lvt_bM02W5p00L0p15_.yml
+++ b/tests/test_components/test_pdk_settings_sky130_fd_pr__rf_nfet_01v8_lvt_bM02W5p00L0p15_.yml
@@ -1,3 +1,3 @@
 info: {}
-name: sky130_fd_pr__rf_nfet_0_82875621
+name: sky130_fd_pr__rf_nfet_01v8_lvt_bM02W5p00L0p15
 settings: {}

--- a/tests/test_components/test_pdk_settings_sky130_fd_pr__rf_nfet_01v8_lvt_bM02W5p00L0p18_.yml
+++ b/tests/test_components/test_pdk_settings_sky130_fd_pr__rf_nfet_01v8_lvt_bM02W5p00L0p18_.yml
@@ -1,3 +1,3 @@
 info: {}
-name: sky130_fd_pr__rf_nfet_0_005ce928
+name: sky130_fd_pr__rf_nfet_01v8_lvt_bM02W5p00L0p18
 settings: {}

--- a/tests/test_components/test_pdk_settings_sky130_fd_pr__rf_nfet_01v8_lvt_bM02W5p00L0p25_.yml
+++ b/tests/test_components/test_pdk_settings_sky130_fd_pr__rf_nfet_01v8_lvt_bM02W5p00L0p25_.yml
@@ -1,3 +1,3 @@
 info: {}
-name: sky130_fd_pr__rf_nfet_0_57ba26ab
+name: sky130_fd_pr__rf_nfet_01v8_lvt_bM02W5p00L0p25
 settings: {}

--- a/tests/test_components/test_pdk_settings_sky130_fd_pr__rf_nfet_01v8_lvt_bM04W1p65L0p15_.yml
+++ b/tests/test_components/test_pdk_settings_sky130_fd_pr__rf_nfet_01v8_lvt_bM04W1p65L0p15_.yml
@@ -1,3 +1,3 @@
 info: {}
-name: sky130_fd_pr__rf_nfet_0_92705776
+name: sky130_fd_pr__rf_nfet_01v8_lvt_bM04W1p65L0p15
 settings: {}

--- a/tests/test_components/test_pdk_settings_sky130_fd_pr__rf_nfet_01v8_lvt_bM04W1p65L0p18_.yml
+++ b/tests/test_components/test_pdk_settings_sky130_fd_pr__rf_nfet_01v8_lvt_bM04W1p65L0p18_.yml
@@ -1,3 +1,3 @@
 info: {}
-name: sky130_fd_pr__rf_nfet_0_25bca700
+name: sky130_fd_pr__rf_nfet_01v8_lvt_bM04W1p65L0p18
 settings: {}

--- a/tests/test_components/test_pdk_settings_sky130_fd_pr__rf_nfet_01v8_lvt_bM04W1p65L0p25_.yml
+++ b/tests/test_components/test_pdk_settings_sky130_fd_pr__rf_nfet_01v8_lvt_bM04W1p65L0p25_.yml
@@ -1,3 +1,3 @@
 info: {}
-name: sky130_fd_pr__rf_nfet_0_b17344e9
+name: sky130_fd_pr__rf_nfet_01v8_lvt_bM04W1p65L0p25
 settings: {}

--- a/tests/test_components/test_pdk_settings_sky130_fd_pr__rf_nfet_01v8_lvt_bM04W3p00L0p15_.yml
+++ b/tests/test_components/test_pdk_settings_sky130_fd_pr__rf_nfet_01v8_lvt_bM04W3p00L0p15_.yml
@@ -1,3 +1,3 @@
 info: {}
-name: sky130_fd_pr__rf_nfet_0_6cec36e5
+name: sky130_fd_pr__rf_nfet_01v8_lvt_bM04W3p00L0p15
 settings: {}

--- a/tests/test_components/test_pdk_settings_sky130_fd_pr__rf_nfet_01v8_lvt_bM04W3p00L0p18_.yml
+++ b/tests/test_components/test_pdk_settings_sky130_fd_pr__rf_nfet_01v8_lvt_bM04W3p00L0p18_.yml
@@ -1,3 +1,3 @@
 info: {}
-name: sky130_fd_pr__rf_nfet_0_55184871
+name: sky130_fd_pr__rf_nfet_01v8_lvt_bM04W3p00L0p18
 settings: {}

--- a/tests/test_components/test_pdk_settings_sky130_fd_pr__rf_nfet_01v8_lvt_bM04W3p00L0p25_.yml
+++ b/tests/test_components/test_pdk_settings_sky130_fd_pr__rf_nfet_01v8_lvt_bM04W3p00L0p25_.yml
@@ -1,3 +1,3 @@
 info: {}
-name: sky130_fd_pr__rf_nfet_0_9d686be4
+name: sky130_fd_pr__rf_nfet_01v8_lvt_bM04W3p00L0p25
 settings: {}

--- a/tests/test_components/test_pdk_settings_sky130_fd_pr__rf_nfet_01v8_lvt_bM04W5p00L0p15_.yml
+++ b/tests/test_components/test_pdk_settings_sky130_fd_pr__rf_nfet_01v8_lvt_bM04W5p00L0p15_.yml
@@ -1,3 +1,3 @@
 info: {}
-name: sky130_fd_pr__rf_nfet_0_70dc6ec8
+name: sky130_fd_pr__rf_nfet_01v8_lvt_bM04W5p00L0p15
 settings: {}

--- a/tests/test_components/test_pdk_settings_sky130_fd_pr__rf_nfet_01v8_lvt_bM04W5p00L0p18_.yml
+++ b/tests/test_components/test_pdk_settings_sky130_fd_pr__rf_nfet_01v8_lvt_bM04W5p00L0p18_.yml
@@ -1,3 +1,3 @@
 info: {}
-name: sky130_fd_pr__rf_nfet_0_6f8b52a9
+name: sky130_fd_pr__rf_nfet_01v8_lvt_bM04W5p00L0p18
 settings: {}

--- a/tests/test_components/test_pdk_settings_sky130_fd_pr__rf_nfet_01v8_lvt_bM04W5p00L0p25_.yml
+++ b/tests/test_components/test_pdk_settings_sky130_fd_pr__rf_nfet_01v8_lvt_bM04W5p00L0p25_.yml
@@ -1,3 +1,3 @@
 info: {}
-name: sky130_fd_pr__rf_nfet_0_aedc36b0
+name: sky130_fd_pr__rf_nfet_01v8_lvt_bM04W5p00L0p25
 settings: {}

--- a/tests/test_components/test_pdk_settings_sky130_fd_pr__rf_nfet_01v8_lvt_cM02W1p65L0p15_.yml
+++ b/tests/test_components/test_pdk_settings_sky130_fd_pr__rf_nfet_01v8_lvt_cM02W1p65L0p15_.yml
@@ -1,3 +1,3 @@
 info: {}
-name: sky130_fd_pr__rf_nfet_0_e1ab446a
+name: sky130_fd_pr__rf_nfet_01v8_lvt_cM02W1p65L0p15
 settings: {}

--- a/tests/test_components/test_pdk_settings_sky130_fd_pr__rf_nfet_01v8_lvt_cM02W1p65L0p18_.yml
+++ b/tests/test_components/test_pdk_settings_sky130_fd_pr__rf_nfet_01v8_lvt_cM02W1p65L0p18_.yml
@@ -1,3 +1,3 @@
 info: {}
-name: sky130_fd_pr__rf_nfet_0_45c04f1a
+name: sky130_fd_pr__rf_nfet_01v8_lvt_cM02W1p65L0p18
 settings: {}

--- a/tests/test_components/test_pdk_settings_sky130_fd_pr__rf_nfet_01v8_lvt_cM02W1p65L0p25_.yml
+++ b/tests/test_components/test_pdk_settings_sky130_fd_pr__rf_nfet_01v8_lvt_cM02W1p65L0p25_.yml
@@ -1,3 +1,3 @@
 info: {}
-name: sky130_fd_pr__rf_nfet_0_b5d7c981
+name: sky130_fd_pr__rf_nfet_01v8_lvt_cM02W1p65L0p25
 settings: {}

--- a/tests/test_components/test_pdk_settings_sky130_fd_pr__rf_nfet_01v8_lvt_cM02W3p00L0p15_.yml
+++ b/tests/test_components/test_pdk_settings_sky130_fd_pr__rf_nfet_01v8_lvt_cM02W3p00L0p15_.yml
@@ -1,3 +1,3 @@
 info: {}
-name: sky130_fd_pr__rf_nfet_0_126458ed
+name: sky130_fd_pr__rf_nfet_01v8_lvt_cM02W3p00L0p15
 settings: {}

--- a/tests/test_components/test_pdk_settings_sky130_fd_pr__rf_nfet_01v8_lvt_cM02W3p00L0p18_.yml
+++ b/tests/test_components/test_pdk_settings_sky130_fd_pr__rf_nfet_01v8_lvt_cM02W3p00L0p18_.yml
@@ -1,3 +1,3 @@
 info: {}
-name: sky130_fd_pr__rf_nfet_0_d0b80382
+name: sky130_fd_pr__rf_nfet_01v8_lvt_cM02W3p00L0p18
 settings: {}

--- a/tests/test_components/test_pdk_settings_sky130_fd_pr__rf_nfet_01v8_lvt_cM02W3p00L0p25_.yml
+++ b/tests/test_components/test_pdk_settings_sky130_fd_pr__rf_nfet_01v8_lvt_cM02W3p00L0p25_.yml
@@ -1,3 +1,3 @@
 info: {}
-name: sky130_fd_pr__rf_nfet_0_16b2bf64
+name: sky130_fd_pr__rf_nfet_01v8_lvt_cM02W3p00L0p25
 settings: {}

--- a/tests/test_components/test_pdk_settings_sky130_fd_pr__rf_nfet_01v8_lvt_cM02W5p00L0p15_.yml
+++ b/tests/test_components/test_pdk_settings_sky130_fd_pr__rf_nfet_01v8_lvt_cM02W5p00L0p15_.yml
@@ -1,3 +1,3 @@
 info: {}
-name: sky130_fd_pr__rf_nfet_0_d21d2d9e
+name: sky130_fd_pr__rf_nfet_01v8_lvt_cM02W5p00L0p15
 settings: {}

--- a/tests/test_components/test_pdk_settings_sky130_fd_pr__rf_nfet_01v8_lvt_cM02W5p00L0p18_.yml
+++ b/tests/test_components/test_pdk_settings_sky130_fd_pr__rf_nfet_01v8_lvt_cM02W5p00L0p18_.yml
@@ -1,3 +1,3 @@
 info: {}
-name: sky130_fd_pr__rf_nfet_0_ec995433
+name: sky130_fd_pr__rf_nfet_01v8_lvt_cM02W5p00L0p18
 settings: {}

--- a/tests/test_components/test_pdk_settings_sky130_fd_pr__rf_nfet_01v8_lvt_cM02W5p00L0p25_.yml
+++ b/tests/test_components/test_pdk_settings_sky130_fd_pr__rf_nfet_01v8_lvt_cM02W5p00L0p25_.yml
@@ -1,3 +1,3 @@
 info: {}
-name: sky130_fd_pr__rf_nfet_0_f381dd27
+name: sky130_fd_pr__rf_nfet_01v8_lvt_cM02W5p00L0p25
 settings: {}

--- a/tests/test_components/test_pdk_settings_sky130_fd_pr__rf_nfet_01v8_lvt_cM04W1p65L0p15_.yml
+++ b/tests/test_components/test_pdk_settings_sky130_fd_pr__rf_nfet_01v8_lvt_cM04W1p65L0p15_.yml
@@ -1,3 +1,3 @@
 info: {}
-name: sky130_fd_pr__rf_nfet_0_df3048de
+name: sky130_fd_pr__rf_nfet_01v8_lvt_cM04W1p65L0p15
 settings: {}

--- a/tests/test_components/test_pdk_settings_sky130_fd_pr__rf_nfet_01v8_lvt_cM04W1p65L0p18_.yml
+++ b/tests/test_components/test_pdk_settings_sky130_fd_pr__rf_nfet_01v8_lvt_cM04W1p65L0p18_.yml
@@ -1,3 +1,3 @@
 info: {}
-name: sky130_fd_pr__rf_nfet_0_98fcc974
+name: sky130_fd_pr__rf_nfet_01v8_lvt_cM04W1p65L0p18
 settings: {}

--- a/tests/test_components/test_pdk_settings_sky130_fd_pr__rf_nfet_01v8_lvt_cM04W1p65L0p25_.yml
+++ b/tests/test_components/test_pdk_settings_sky130_fd_pr__rf_nfet_01v8_lvt_cM04W1p65L0p25_.yml
@@ -1,3 +1,3 @@
 info: {}
-name: sky130_fd_pr__rf_nfet_0_a75e59a8
+name: sky130_fd_pr__rf_nfet_01v8_lvt_cM04W1p65L0p25
 settings: {}

--- a/tests/test_components/test_pdk_settings_sky130_fd_pr__rf_nfet_01v8_lvt_cM04W3p00L0p15_.yml
+++ b/tests/test_components/test_pdk_settings_sky130_fd_pr__rf_nfet_01v8_lvt_cM04W3p00L0p15_.yml
@@ -1,3 +1,3 @@
 info: {}
-name: sky130_fd_pr__rf_nfet_0_e9360aa6
+name: sky130_fd_pr__rf_nfet_01v8_lvt_cM04W3p00L0p15
 settings: {}

--- a/tests/test_components/test_pdk_settings_sky130_fd_pr__rf_nfet_01v8_lvt_cM04W3p00L0p18_.yml
+++ b/tests/test_components/test_pdk_settings_sky130_fd_pr__rf_nfet_01v8_lvt_cM04W3p00L0p18_.yml
@@ -1,3 +1,3 @@
 info: {}
-name: sky130_fd_pr__rf_nfet_0_e531f9f1
+name: sky130_fd_pr__rf_nfet_01v8_lvt_cM04W3p00L0p18
 settings: {}

--- a/tests/test_components/test_pdk_settings_sky130_fd_pr__rf_nfet_01v8_lvt_cM04W3p00L0p25_.yml
+++ b/tests/test_components/test_pdk_settings_sky130_fd_pr__rf_nfet_01v8_lvt_cM04W3p00L0p25_.yml
@@ -1,3 +1,3 @@
 info: {}
-name: sky130_fd_pr__rf_nfet_0_2f25e565
+name: sky130_fd_pr__rf_nfet_01v8_lvt_cM04W3p00L0p25
 settings: {}

--- a/tests/test_components/test_pdk_settings_sky130_fd_pr__rf_nfet_01v8_lvt_cM04W5p00L0p15_.yml
+++ b/tests/test_components/test_pdk_settings_sky130_fd_pr__rf_nfet_01v8_lvt_cM04W5p00L0p15_.yml
@@ -1,3 +1,3 @@
 info: {}
-name: sky130_fd_pr__rf_nfet_0_6382ff24
+name: sky130_fd_pr__rf_nfet_01v8_lvt_cM04W5p00L0p15
 settings: {}

--- a/tests/test_components/test_pdk_settings_sky130_fd_pr__rf_nfet_01v8_lvt_cM04W5p00L0p18_.yml
+++ b/tests/test_components/test_pdk_settings_sky130_fd_pr__rf_nfet_01v8_lvt_cM04W5p00L0p18_.yml
@@ -1,3 +1,3 @@
 info: {}
-name: sky130_fd_pr__rf_nfet_0_754d50e2
+name: sky130_fd_pr__rf_nfet_01v8_lvt_cM04W5p00L0p18
 settings: {}

--- a/tests/test_components/test_pdk_settings_sky130_fd_pr__rf_nfet_01v8_lvt_cM04W5p00L0p25_.yml
+++ b/tests/test_components/test_pdk_settings_sky130_fd_pr__rf_nfet_01v8_lvt_cM04W5p00L0p25_.yml
@@ -1,3 +1,3 @@
 info: {}
-name: sky130_fd_pr__rf_nfet_0_c9a6e973
+name: sky130_fd_pr__rf_nfet_01v8_lvt_cM04W5p00L0p25
 settings: {}

--- a/tests/test_components/test_pdk_settings_sky130_fd_pr__rf_nfet_01v8_mcM04W3p00L0p15_.yml
+++ b/tests/test_components/test_pdk_settings_sky130_fd_pr__rf_nfet_01v8_mcM04W3p00L0p15_.yml
@@ -1,3 +1,3 @@
 info: {}
-name: sky130_fd_pr__rf_nfet_0_82c0bd7e
+name: sky130_fd_pr__rf_nfet_01v8_mcM04W3p00L0p15
 settings: {}

--- a/tests/test_components/test_pdk_settings_sky130_fd_pr__rf_nfet_01v8_mcM04W5p00L0p15_.yml
+++ b/tests/test_components/test_pdk_settings_sky130_fd_pr__rf_nfet_01v8_mcM04W5p00L0p15_.yml
@@ -1,3 +1,3 @@
 info: {}
-name: sky130_fd_pr__rf_nfet_0_534ed698
+name: sky130_fd_pr__rf_nfet_01v8_mcM04W5p00L0p15
 settings: {}

--- a/tests/test_components/test_pdk_settings_sky130_fd_pr__rf_nfet_20v0_noptap_iso_.yml
+++ b/tests/test_components/test_pdk_settings_sky130_fd_pr__rf_nfet_20v0_noptap_iso_.yml
@@ -1,3 +1,3 @@
 info: {}
-name: sky130_fd_pr__rf_nfet_2_2523899c
+name: sky130_fd_pr__rf_nfet_20v0_noptap_iso
 settings: {}

--- a/tests/test_components/test_pdk_settings_sky130_fd_pr__rf_nfet_20v0_nvt_aup_.yml
+++ b/tests/test_components/test_pdk_settings_sky130_fd_pr__rf_nfet_20v0_nvt_aup_.yml
@@ -1,3 +1,3 @@
 info: {}
-name: sky130_fd_pr__rf_nfet_2_d35da39b
+name: sky130_fd_pr__rf_nfet_20v0_nvt_aup
 settings: {}

--- a/tests/test_components/test_pdk_settings_sky130_fd_pr__rf_nfet_20v0_nvt_noptap_iso_.yml
+++ b/tests/test_components/test_pdk_settings_sky130_fd_pr__rf_nfet_20v0_nvt_noptap_iso_.yml
@@ -1,3 +1,3 @@
 info: {}
-name: sky130_fd_pr__rf_nfet_2_b16daaf4
+name: sky130_fd_pr__rf_nfet_20v0_nvt_noptap_iso
 settings: {}

--- a/tests/test_components/test_pdk_settings_sky130_fd_pr__rf_nfet_20v0_nvt_withptap_.yml
+++ b/tests/test_components/test_pdk_settings_sky130_fd_pr__rf_nfet_20v0_nvt_withptap_.yml
@@ -1,3 +1,3 @@
 info: {}
-name: sky130_fd_pr__rf_nfet_2_0137ee05
+name: sky130_fd_pr__rf_nfet_20v0_nvt_withptap
 settings: {}

--- a/tests/test_components/test_pdk_settings_sky130_fd_pr__rf_nfet_20v0_nvt_withptap_iso_.yml
+++ b/tests/test_components/test_pdk_settings_sky130_fd_pr__rf_nfet_20v0_nvt_withptap_iso_.yml
@@ -1,3 +1,3 @@
 info: {}
-name: sky130_fd_pr__rf_nfet_2_a161b4f1
+name: sky130_fd_pr__rf_nfet_20v0_nvt_withptap_iso
 settings: {}

--- a/tests/test_components/test_pdk_settings_sky130_fd_pr__rf_nfet_20v0_withptap_.yml
+++ b/tests/test_components/test_pdk_settings_sky130_fd_pr__rf_nfet_20v0_withptap_.yml
@@ -1,3 +1,3 @@
 info: {}
-name: sky130_fd_pr__rf_nfet_2_f1b87e0c
+name: sky130_fd_pr__rf_nfet_20v0_withptap
 settings: {}

--- a/tests/test_components/test_pdk_settings_sky130_fd_pr__rf_nfet_20v0_withptap_iso_.yml
+++ b/tests/test_components/test_pdk_settings_sky130_fd_pr__rf_nfet_20v0_withptap_iso_.yml
@@ -1,3 +1,3 @@
 info: {}
-name: sky130_fd_pr__rf_nfet_2_82d63ef5
+name: sky130_fd_pr__rf_nfet_20v0_withptap_iso
 settings: {}

--- a/tests/test_components/test_pdk_settings_sky130_fd_pr__rf_nfet_20v0_zvt_withptap_.yml
+++ b/tests/test_components/test_pdk_settings_sky130_fd_pr__rf_nfet_20v0_zvt_withptap_.yml
@@ -1,3 +1,3 @@
 info: {}
-name: sky130_fd_pr__rf_nfet_2_173bcec0
+name: sky130_fd_pr__rf_nfet_20v0_zvt_withptap
 settings: {}

--- a/tests/test_components/test_pdk_settings_sky130_fd_pr__rf_nfet_g5v0d10v5_aM04W3p00L0p50_.yml
+++ b/tests/test_components/test_pdk_settings_sky130_fd_pr__rf_nfet_g5v0d10v5_aM04W3p00L0p50_.yml
@@ -1,3 +1,3 @@
 info: {}
-name: sky130_fd_pr__rf_nfet_g_b049588b
+name: sky130_fd_pr__rf_nfet_g5v0d10v5_aM04W3p00L0p50
 settings: {}

--- a/tests/test_components/test_pdk_settings_sky130_fd_pr__rf_nfet_g5v0d10v5_aM04W5p00L0p50_.yml
+++ b/tests/test_components/test_pdk_settings_sky130_fd_pr__rf_nfet_g5v0d10v5_aM04W5p00L0p50_.yml
@@ -1,3 +1,3 @@
 info: {}
-name: sky130_fd_pr__rf_nfet_g_cdf24f57
+name: sky130_fd_pr__rf_nfet_g5v0d10v5_aM04W5p00L0p50
 settings: {}

--- a/tests/test_components/test_pdk_settings_sky130_fd_pr__rf_nfet_g5v0d10v5_aM04W7p00L0p50_.yml
+++ b/tests/test_components/test_pdk_settings_sky130_fd_pr__rf_nfet_g5v0d10v5_aM04W7p00L0p50_.yml
@@ -1,3 +1,3 @@
 info: {}
-name: sky130_fd_pr__rf_nfet_g_0bcb7003
+name: sky130_fd_pr__rf_nfet_g5v0d10v5_aM04W7p00L0p50
 settings: {}

--- a/tests/test_components/test_pdk_settings_sky130_fd_pr__rf_nfet_g5v0d10v5_aM10W3p00L0p50_.yml
+++ b/tests/test_components/test_pdk_settings_sky130_fd_pr__rf_nfet_g5v0d10v5_aM10W3p00L0p50_.yml
@@ -1,3 +1,3 @@
 info: {}
-name: sky130_fd_pr__rf_nfet_g_f94e8587
+name: sky130_fd_pr__rf_nfet_g5v0d10v5_aM10W3p00L0p50
 settings: {}

--- a/tests/test_components/test_pdk_settings_sky130_fd_pr__rf_nfet_g5v0d10v5_aM10W5p00L0p50_.yml
+++ b/tests/test_components/test_pdk_settings_sky130_fd_pr__rf_nfet_g5v0d10v5_aM10W5p00L0p50_.yml
@@ -1,3 +1,3 @@
 info: {}
-name: sky130_fd_pr__rf_nfet_g_8b9d815e
+name: sky130_fd_pr__rf_nfet_g5v0d10v5_aM10W5p00L0p50
 settings: {}

--- a/tests/test_components/test_pdk_settings_sky130_fd_pr__rf_nfet_g5v0d10v5_aM10W7p00L0p50_.yml
+++ b/tests/test_components/test_pdk_settings_sky130_fd_pr__rf_nfet_g5v0d10v5_aM10W7p00L0p50_.yml
@@ -1,3 +1,3 @@
 info: {}
-name: sky130_fd_pr__rf_nfet_g_ecc1c65d
+name: sky130_fd_pr__rf_nfet_g5v0d10v5_aM10W7p00L0p50
 settings: {}

--- a/tests/test_components/test_pdk_settings_sky130_fd_pr__rf_nfet_g5v0d10v5_bM02W3p00L0p50_.yml
+++ b/tests/test_components/test_pdk_settings_sky130_fd_pr__rf_nfet_g5v0d10v5_bM02W3p00L0p50_.yml
@@ -1,3 +1,3 @@
 info: {}
-name: sky130_fd_pr__rf_nfet_g_d3e6bde1
+name: sky130_fd_pr__rf_nfet_g5v0d10v5_bM02W3p00L0p50
 settings: {}

--- a/tests/test_components/test_pdk_settings_sky130_fd_pr__rf_nfet_g5v0d10v5_bM02W5p00L0p50_.yml
+++ b/tests/test_components/test_pdk_settings_sky130_fd_pr__rf_nfet_g5v0d10v5_bM02W5p00L0p50_.yml
@@ -1,3 +1,3 @@
 info: {}
-name: sky130_fd_pr__rf_nfet_g_45323c03
+name: sky130_fd_pr__rf_nfet_g5v0d10v5_bM02W5p00L0p50
 settings: {}

--- a/tests/test_components/test_pdk_settings_sky130_fd_pr__rf_nfet_g5v0d10v5_bM04W3p00L0p50_.yml
+++ b/tests/test_components/test_pdk_settings_sky130_fd_pr__rf_nfet_g5v0d10v5_bM04W3p00L0p50_.yml
@@ -1,3 +1,3 @@
 info: {}
-name: sky130_fd_pr__rf_nfet_g_139ea58d
+name: sky130_fd_pr__rf_nfet_g5v0d10v5_bM04W3p00L0p50
 settings: {}

--- a/tests/test_components/test_pdk_settings_sky130_fd_pr__rf_nfet_g5v0d10v5_bM04W5p00L0p50_.yml
+++ b/tests/test_components/test_pdk_settings_sky130_fd_pr__rf_nfet_g5v0d10v5_bM04W5p00L0p50_.yml
@@ -1,3 +1,3 @@
 info: {}
-name: sky130_fd_pr__rf_nfet_g_913e41bb
+name: sky130_fd_pr__rf_nfet_g5v0d10v5_bM04W5p00L0p50
 settings: {}

--- a/tests/test_components/test_pdk_settings_sky130_fd_pr__rf_nfet_g5v0d10v5_bM04W7p00L0p50_.yml
+++ b/tests/test_components/test_pdk_settings_sky130_fd_pr__rf_nfet_g5v0d10v5_bM04W7p00L0p50_.yml
@@ -1,3 +1,3 @@
 info: {}
-name: sky130_fd_pr__rf_nfet_g_84c0a662
+name: sky130_fd_pr__rf_nfet_g5v0d10v5_bM04W7p00L0p50
 settings: {}

--- a/tests/test_components/test_pdk_settings_sky130_fd_pr__rf_nfet_g5v0d10v5_bM10W3p00L0p50_.yml
+++ b/tests/test_components/test_pdk_settings_sky130_fd_pr__rf_nfet_g5v0d10v5_bM10W3p00L0p50_.yml
@@ -1,3 +1,3 @@
 info: {}
-name: sky130_fd_pr__rf_nfet_g_03e18a45
+name: sky130_fd_pr__rf_nfet_g5v0d10v5_bM10W3p00L0p50
 settings: {}

--- a/tests/test_components/test_pdk_settings_sky130_fd_pr__rf_nfet_g5v0d10v5_bM10W5p00L0p50_.yml
+++ b/tests/test_components/test_pdk_settings_sky130_fd_pr__rf_nfet_g5v0d10v5_bM10W5p00L0p50_.yml
@@ -1,3 +1,3 @@
 info: {}
-name: sky130_fd_pr__rf_nfet_g_2a6cc613
+name: sky130_fd_pr__rf_nfet_g5v0d10v5_bM10W5p00L0p50
 settings: {}

--- a/tests/test_components/test_pdk_settings_sky130_fd_pr__rf_nfet_g5v0d10v5_bM10W7p00L0p50_.yml
+++ b/tests/test_components/test_pdk_settings_sky130_fd_pr__rf_nfet_g5v0d10v5_bM10W7p00L0p50_.yml
@@ -1,3 +1,3 @@
 info: {}
-name: sky130_fd_pr__rf_nfet_g_e89851d5
+name: sky130_fd_pr__rf_nfet_g5v0d10v5_bM10W7p00L0p50
 settings: {}

--- a/tests/test_components/test_pdk_settings_sky130_fd_pr__rf_npn_05v5_W1p00L1p00_.yml
+++ b/tests/test_components/test_pdk_settings_sky130_fd_pr__rf_npn_05v5_W1p00L1p00_.yml
@@ -1,3 +1,3 @@
 info: {}
-name: sky130_fd_pr__rf_npn_05_4a5a6c23
+name: sky130_fd_pr__rf_npn_05v5_W1p00L1p00
 settings: {}

--- a/tests/test_components/test_pdk_settings_sky130_fd_pr__rf_npn_05v5_W1p00L2p00_.yml
+++ b/tests/test_components/test_pdk_settings_sky130_fd_pr__rf_npn_05v5_W1p00L2p00_.yml
@@ -1,3 +1,3 @@
 info: {}
-name: sky130_fd_pr__rf_npn_05_2b486c26
+name: sky130_fd_pr__rf_npn_05v5_W1p00L2p00
 settings: {}

--- a/tests/test_components/test_pdk_settings_sky130_fd_pr__rf_npn_05v5_W1p00L4p00_.yml
+++ b/tests/test_components/test_pdk_settings_sky130_fd_pr__rf_npn_05v5_W1p00L4p00_.yml
@@ -1,3 +1,3 @@
 info: {}
-name: sky130_fd_pr__rf_npn_05_adc83a38
+name: sky130_fd_pr__rf_npn_05v5_W1p00L4p00
 settings: {}

--- a/tests/test_components/test_pdk_settings_sky130_fd_pr__rf_npn_05v5_W1p00L8p00_.yml
+++ b/tests/test_components/test_pdk_settings_sky130_fd_pr__rf_npn_05v5_W1p00L8p00_.yml
@@ -1,3 +1,3 @@
 info: {}
-name: sky130_fd_pr__rf_npn_05_d9b3f63f
+name: sky130_fd_pr__rf_npn_05v5_W1p00L8p00
 settings: {}

--- a/tests/test_components/test_pdk_settings_sky130_fd_pr__rf_npn_05v5_W2p00L2p00_.yml
+++ b/tests/test_components/test_pdk_settings_sky130_fd_pr__rf_npn_05v5_W2p00L2p00_.yml
@@ -1,3 +1,3 @@
 info: {}
-name: sky130_fd_pr__rf_npn_05_f01acfe8
+name: sky130_fd_pr__rf_npn_05v5_W2p00L2p00
 settings: {}

--- a/tests/test_components/test_pdk_settings_sky130_fd_pr__rf_npn_05v5_W2p00L4p00_.yml
+++ b/tests/test_components/test_pdk_settings_sky130_fd_pr__rf_npn_05v5_W2p00L4p00_.yml
@@ -1,3 +1,3 @@
 info: {}
-name: sky130_fd_pr__rf_npn_05_febcd3cf
+name: sky130_fd_pr__rf_npn_05v5_W2p00L4p00
 settings: {}

--- a/tests/test_components/test_pdk_settings_sky130_fd_pr__rf_npn_05v5_W2p00L8p00_.yml
+++ b/tests/test_components/test_pdk_settings_sky130_fd_pr__rf_npn_05v5_W2p00L8p00_.yml
@@ -1,3 +1,3 @@
 info: {}
-name: sky130_fd_pr__rf_npn_05_32d50adb
+name: sky130_fd_pr__rf_npn_05v5_W2p00L8p00
 settings: {}

--- a/tests/test_components/test_pdk_settings_sky130_fd_pr__rf_npn_05v5_W5p00L5p00_.yml
+++ b/tests/test_components/test_pdk_settings_sky130_fd_pr__rf_npn_05v5_W5p00L5p00_.yml
@@ -1,3 +1,3 @@
 info: {}
-name: sky130_fd_pr__rf_npn_05_8a761d6b
+name: sky130_fd_pr__rf_npn_05v5_W5p00L5p00
 settings: {}

--- a/tests/test_components/test_pdk_settings_sky130_fd_pr__rf_npn_11v0_W1p00L1p00_.yml
+++ b/tests/test_components/test_pdk_settings_sky130_fd_pr__rf_npn_11v0_W1p00L1p00_.yml
@@ -1,3 +1,3 @@
 info: {}
-name: sky130_fd_pr__rf_npn_11_fd82b914
+name: sky130_fd_pr__rf_npn_11v0_W1p00L1p00
 settings: {}

--- a/tests/test_components/test_pdk_settings_sky130_fd_pr__rf_pfet_01v8_aF02W0p84L0p15_.yml
+++ b/tests/test_components/test_pdk_settings_sky130_fd_pr__rf_pfet_01v8_aF02W0p84L0p15_.yml
@@ -1,3 +1,3 @@
 info: {}
-name: sky130_fd_pr__rf_pfet_0_7dd2f477
+name: sky130_fd_pr__rf_pfet_01v8_aF02W0p84L0p15
 settings: {}

--- a/tests/test_components/test_pdk_settings_sky130_fd_pr__rf_pfet_01v8_aF02W1p68L0p15_.yml
+++ b/tests/test_components/test_pdk_settings_sky130_fd_pr__rf_pfet_01v8_aF02W1p68L0p15_.yml
@@ -1,3 +1,3 @@
 info: {}
-name: sky130_fd_pr__rf_pfet_0_0832e563
+name: sky130_fd_pr__rf_pfet_01v8_aF02W1p68L0p15
 settings: {}

--- a/tests/test_components/test_pdk_settings_sky130_fd_pr__rf_pfet_01v8_aF02W2p00L0p15_.yml
+++ b/tests/test_components/test_pdk_settings_sky130_fd_pr__rf_pfet_01v8_aF02W2p00L0p15_.yml
@@ -1,3 +1,3 @@
 info: {}
-name: sky130_fd_pr__rf_pfet_0_ba5910c2
+name: sky130_fd_pr__rf_pfet_01v8_aF02W2p00L0p15
 settings: {}

--- a/tests/test_components/test_pdk_settings_sky130_fd_pr__rf_pfet_01v8_aF02W3p00L0p15_.yml
+++ b/tests/test_components/test_pdk_settings_sky130_fd_pr__rf_pfet_01v8_aF02W3p00L0p15_.yml
@@ -1,3 +1,3 @@
 info: {}
-name: sky130_fd_pr__rf_pfet_0_2e9dc632
+name: sky130_fd_pr__rf_pfet_01v8_aF02W3p00L0p15
 settings: {}

--- a/tests/test_components/test_pdk_settings_sky130_fd_pr__rf_pfet_01v8_aF02W5p00L0p15_.yml
+++ b/tests/test_components/test_pdk_settings_sky130_fd_pr__rf_pfet_01v8_aF02W5p00L0p15_.yml
@@ -1,3 +1,3 @@
 info: {}
-name: sky130_fd_pr__rf_pfet_0_eb9daa3d
+name: sky130_fd_pr__rf_pfet_01v8_aF02W5p00L0p15
 settings: {}

--- a/tests/test_components/test_pdk_settings_sky130_fd_pr__rf_pfet_01v8_aF04W0p84L0p15_.yml
+++ b/tests/test_components/test_pdk_settings_sky130_fd_pr__rf_pfet_01v8_aF04W0p84L0p15_.yml
@@ -1,3 +1,3 @@
 info: {}
-name: sky130_fd_pr__rf_pfet_0_442a1117
+name: sky130_fd_pr__rf_pfet_01v8_aF04W0p84L0p15
 settings: {}

--- a/tests/test_components/test_pdk_settings_sky130_fd_pr__rf_pfet_01v8_aF04W1p68L0p15_.yml
+++ b/tests/test_components/test_pdk_settings_sky130_fd_pr__rf_pfet_01v8_aF04W1p68L0p15_.yml
@@ -1,3 +1,3 @@
 info: {}
-name: sky130_fd_pr__rf_pfet_0_38fa764b
+name: sky130_fd_pr__rf_pfet_01v8_aF04W1p68L0p15
 settings: {}

--- a/tests/test_components/test_pdk_settings_sky130_fd_pr__rf_pfet_01v8_aF04W2p00L0p15_.yml
+++ b/tests/test_components/test_pdk_settings_sky130_fd_pr__rf_pfet_01v8_aF04W2p00L0p15_.yml
@@ -1,3 +1,3 @@
 info: {}
-name: sky130_fd_pr__rf_pfet_0_9be4c8fb
+name: sky130_fd_pr__rf_pfet_01v8_aF04W2p00L0p15
 settings: {}

--- a/tests/test_components/test_pdk_settings_sky130_fd_pr__rf_pfet_01v8_aF04W3p00L0p15_.yml
+++ b/tests/test_components/test_pdk_settings_sky130_fd_pr__rf_pfet_01v8_aF04W3p00L0p15_.yml
@@ -1,3 +1,3 @@
 info: {}
-name: sky130_fd_pr__rf_pfet_0_9ef94b42
+name: sky130_fd_pr__rf_pfet_01v8_aF04W3p00L0p15
 settings: {}

--- a/tests/test_components/test_pdk_settings_sky130_fd_pr__rf_pfet_01v8_aF04W5p00L0p15_.yml
+++ b/tests/test_components/test_pdk_settings_sky130_fd_pr__rf_pfet_01v8_aF04W5p00L0p15_.yml
@@ -1,3 +1,3 @@
 info: {}
-name: sky130_fd_pr__rf_pfet_0_4e5df3eb
+name: sky130_fd_pr__rf_pfet_01v8_aF04W5p00L0p15
 settings: {}

--- a/tests/test_components/test_pdk_settings_sky130_fd_pr__rf_pfet_01v8_aF06W0p84L0p15_.yml
+++ b/tests/test_components/test_pdk_settings_sky130_fd_pr__rf_pfet_01v8_aF06W0p84L0p15_.yml
@@ -1,3 +1,3 @@
 info: {}
-name: sky130_fd_pr__rf_pfet_0_8d9affa9
+name: sky130_fd_pr__rf_pfet_01v8_aF06W0p84L0p15
 settings: {}

--- a/tests/test_components/test_pdk_settings_sky130_fd_pr__rf_pfet_01v8_aF06W1p68L0p15_.yml
+++ b/tests/test_components/test_pdk_settings_sky130_fd_pr__rf_pfet_01v8_aF06W1p68L0p15_.yml
@@ -1,3 +1,3 @@
 info: {}
-name: sky130_fd_pr__rf_pfet_0_dec161bc
+name: sky130_fd_pr__rf_pfet_01v8_aF06W1p68L0p15
 settings: {}

--- a/tests/test_components/test_pdk_settings_sky130_fd_pr__rf_pfet_01v8_aF06W2p00L0p15_.yml
+++ b/tests/test_components/test_pdk_settings_sky130_fd_pr__rf_pfet_01v8_aF06W2p00L0p15_.yml
@@ -1,3 +1,3 @@
 info: {}
-name: sky130_fd_pr__rf_pfet_0_9d540cde
+name: sky130_fd_pr__rf_pfet_01v8_aF06W2p00L0p15
 settings: {}

--- a/tests/test_components/test_pdk_settings_sky130_fd_pr__rf_pfet_01v8_aF06W3p00L0p15_.yml
+++ b/tests/test_components/test_pdk_settings_sky130_fd_pr__rf_pfet_01v8_aF06W3p00L0p15_.yml
@@ -1,3 +1,3 @@
 info: {}
-name: sky130_fd_pr__rf_pfet_0_679bbcfa
+name: sky130_fd_pr__rf_pfet_01v8_aF06W3p00L0p15
 settings: {}

--- a/tests/test_components/test_pdk_settings_sky130_fd_pr__rf_pfet_01v8_aF08W0p84L0p15_.yml
+++ b/tests/test_components/test_pdk_settings_sky130_fd_pr__rf_pfet_01v8_aF08W0p84L0p15_.yml
@@ -1,3 +1,3 @@
 info: {}
-name: sky130_fd_pr__rf_pfet_0_f4db132e
+name: sky130_fd_pr__rf_pfet_01v8_aF08W0p84L0p15
 settings: {}

--- a/tests/test_components/test_pdk_settings_sky130_fd_pr__rf_pfet_01v8_aF08W1p68L0p15_.yml
+++ b/tests/test_components/test_pdk_settings_sky130_fd_pr__rf_pfet_01v8_aF08W1p68L0p15_.yml
@@ -1,3 +1,3 @@
 info: {}
-name: sky130_fd_pr__rf_pfet_0_191d7612
+name: sky130_fd_pr__rf_pfet_01v8_aF08W1p68L0p15
 settings: {}

--- a/tests/test_components/test_pdk_settings_sky130_fd_pr__rf_pfet_01v8_aM02W1p65L0p15_.yml
+++ b/tests/test_components/test_pdk_settings_sky130_fd_pr__rf_pfet_01v8_aM02W1p65L0p15_.yml
@@ -1,3 +1,3 @@
 info: {}
-name: sky130_fd_pr__rf_pfet_0_39b11a5b
+name: sky130_fd_pr__rf_pfet_01v8_aM02W1p65L0p15
 settings: {}

--- a/tests/test_components/test_pdk_settings_sky130_fd_pr__rf_pfet_01v8_aM02W1p65L0p18_.yml
+++ b/tests/test_components/test_pdk_settings_sky130_fd_pr__rf_pfet_01v8_aM02W1p65L0p18_.yml
@@ -1,3 +1,3 @@
 info: {}
-name: sky130_fd_pr__rf_pfet_0_e5b11d01
+name: sky130_fd_pr__rf_pfet_01v8_aM02W1p65L0p18
 settings: {}

--- a/tests/test_components/test_pdk_settings_sky130_fd_pr__rf_pfet_01v8_aM02W1p65L0p25_.yml
+++ b/tests/test_components/test_pdk_settings_sky130_fd_pr__rf_pfet_01v8_aM02W1p65L0p25_.yml
@@ -1,3 +1,3 @@
 info: {}
-name: sky130_fd_pr__rf_pfet_0_93f94702
+name: sky130_fd_pr__rf_pfet_01v8_aM02W1p65L0p25
 settings: {}

--- a/tests/test_components/test_pdk_settings_sky130_fd_pr__rf_pfet_01v8_aM02W3p00L0p15_.yml
+++ b/tests/test_components/test_pdk_settings_sky130_fd_pr__rf_pfet_01v8_aM02W3p00L0p15_.yml
@@ -1,3 +1,3 @@
 info: {}
-name: sky130_fd_pr__rf_pfet_0_825005ca
+name: sky130_fd_pr__rf_pfet_01v8_aM02W3p00L0p15
 settings: {}

--- a/tests/test_components/test_pdk_settings_sky130_fd_pr__rf_pfet_01v8_aM02W3p00L0p18_.yml
+++ b/tests/test_components/test_pdk_settings_sky130_fd_pr__rf_pfet_01v8_aM02W3p00L0p18_.yml
@@ -1,3 +1,3 @@
 info: {}
-name: sky130_fd_pr__rf_pfet_0_4a90db02
+name: sky130_fd_pr__rf_pfet_01v8_aM02W3p00L0p18
 settings: {}

--- a/tests/test_components/test_pdk_settings_sky130_fd_pr__rf_pfet_01v8_aM02W3p00L0p25_.yml
+++ b/tests/test_components/test_pdk_settings_sky130_fd_pr__rf_pfet_01v8_aM02W3p00L0p25_.yml
@@ -1,3 +1,3 @@
 info: {}
-name: sky130_fd_pr__rf_pfet_0_89033b20
+name: sky130_fd_pr__rf_pfet_01v8_aM02W3p00L0p25
 settings: {}

--- a/tests/test_components/test_pdk_settings_sky130_fd_pr__rf_pfet_01v8_aM02W5p00L0p15_.yml
+++ b/tests/test_components/test_pdk_settings_sky130_fd_pr__rf_pfet_01v8_aM02W5p00L0p15_.yml
@@ -1,3 +1,3 @@
 info: {}
-name: sky130_fd_pr__rf_pfet_0_b43847c0
+name: sky130_fd_pr__rf_pfet_01v8_aM02W5p00L0p15
 settings: {}

--- a/tests/test_components/test_pdk_settings_sky130_fd_pr__rf_pfet_01v8_aM02W5p00L0p18_.yml
+++ b/tests/test_components/test_pdk_settings_sky130_fd_pr__rf_pfet_01v8_aM02W5p00L0p18_.yml
@@ -1,3 +1,3 @@
 info: {}
-name: sky130_fd_pr__rf_pfet_0_341adf2a
+name: sky130_fd_pr__rf_pfet_01v8_aM02W5p00L0p18
 settings: {}

--- a/tests/test_components/test_pdk_settings_sky130_fd_pr__rf_pfet_01v8_aM02W5p00L0p25_.yml
+++ b/tests/test_components/test_pdk_settings_sky130_fd_pr__rf_pfet_01v8_aM02W5p00L0p25_.yml
@@ -1,3 +1,3 @@
 info: {}
-name: sky130_fd_pr__rf_pfet_0_46e99691
+name: sky130_fd_pr__rf_pfet_01v8_aM02W5p00L0p25
 settings: {}

--- a/tests/test_components/test_pdk_settings_sky130_fd_pr__rf_pfet_01v8_aM04W1p65L0p15_.yml
+++ b/tests/test_components/test_pdk_settings_sky130_fd_pr__rf_pfet_01v8_aM04W1p65L0p15_.yml
@@ -1,3 +1,3 @@
 info: {}
-name: sky130_fd_pr__rf_pfet_0_9456ec02
+name: sky130_fd_pr__rf_pfet_01v8_aM04W1p65L0p15
 settings: {}

--- a/tests/test_components/test_pdk_settings_sky130_fd_pr__rf_pfet_01v8_aM04W1p65L0p18_.yml
+++ b/tests/test_components/test_pdk_settings_sky130_fd_pr__rf_pfet_01v8_aM04W1p65L0p18_.yml
@@ -1,3 +1,3 @@
 info: {}
-name: sky130_fd_pr__rf_pfet_0_90e18c0e
+name: sky130_fd_pr__rf_pfet_01v8_aM04W1p65L0p18
 settings: {}

--- a/tests/test_components/test_pdk_settings_sky130_fd_pr__rf_pfet_01v8_aM04W1p65L0p25_.yml
+++ b/tests/test_components/test_pdk_settings_sky130_fd_pr__rf_pfet_01v8_aM04W1p65L0p25_.yml
@@ -1,3 +1,3 @@
 info: {}
-name: sky130_fd_pr__rf_pfet_0_1a7a2fcc
+name: sky130_fd_pr__rf_pfet_01v8_aM04W1p65L0p25
 settings: {}

--- a/tests/test_components/test_pdk_settings_sky130_fd_pr__rf_pfet_01v8_aM04W3p00L0p15_.yml
+++ b/tests/test_components/test_pdk_settings_sky130_fd_pr__rf_pfet_01v8_aM04W3p00L0p15_.yml
@@ -1,3 +1,3 @@
 info: {}
-name: sky130_fd_pr__rf_pfet_0_f3fae254
+name: sky130_fd_pr__rf_pfet_01v8_aM04W3p00L0p15
 settings: {}

--- a/tests/test_components/test_pdk_settings_sky130_fd_pr__rf_pfet_01v8_aM04W3p00L0p18_.yml
+++ b/tests/test_components/test_pdk_settings_sky130_fd_pr__rf_pfet_01v8_aM04W3p00L0p18_.yml
@@ -1,3 +1,3 @@
 info: {}
-name: sky130_fd_pr__rf_pfet_0_b96d144e
+name: sky130_fd_pr__rf_pfet_01v8_aM04W3p00L0p18
 settings: {}

--- a/tests/test_components/test_pdk_settings_sky130_fd_pr__rf_pfet_01v8_aM04W3p00L0p25_.yml
+++ b/tests/test_components/test_pdk_settings_sky130_fd_pr__rf_pfet_01v8_aM04W3p00L0p25_.yml
@@ -1,3 +1,3 @@
 info: {}
-name: sky130_fd_pr__rf_pfet_0_a6fd6c74
+name: sky130_fd_pr__rf_pfet_01v8_aM04W3p00L0p25
 settings: {}

--- a/tests/test_components/test_pdk_settings_sky130_fd_pr__rf_pfet_01v8_aM04W5p00L0p15_.yml
+++ b/tests/test_components/test_pdk_settings_sky130_fd_pr__rf_pfet_01v8_aM04W5p00L0p15_.yml
@@ -1,3 +1,3 @@
 info: {}
-name: sky130_fd_pr__rf_pfet_0_dd125617
+name: sky130_fd_pr__rf_pfet_01v8_aM04W5p00L0p15
 settings: {}

--- a/tests/test_components/test_pdk_settings_sky130_fd_pr__rf_pfet_01v8_aM04W5p00L0p18_.yml
+++ b/tests/test_components/test_pdk_settings_sky130_fd_pr__rf_pfet_01v8_aM04W5p00L0p18_.yml
@@ -1,3 +1,3 @@
 info: {}
-name: sky130_fd_pr__rf_pfet_0_fe7c0326
+name: sky130_fd_pr__rf_pfet_01v8_aM04W5p00L0p18
 settings: {}

--- a/tests/test_components/test_pdk_settings_sky130_fd_pr__rf_pfet_01v8_aM04W5p00L0p25_.yml
+++ b/tests/test_components/test_pdk_settings_sky130_fd_pr__rf_pfet_01v8_aM04W5p00L0p25_.yml
@@ -1,3 +1,3 @@
 info: {}
-name: sky130_fd_pr__rf_pfet_0_5c1cd38e
+name: sky130_fd_pr__rf_pfet_01v8_aM04W5p00L0p25
 settings: {}

--- a/tests/test_components/test_pdk_settings_sky130_fd_pr__rf_pfet_01v8_bM02W1p65L0p15_.yml
+++ b/tests/test_components/test_pdk_settings_sky130_fd_pr__rf_pfet_01v8_bM02W1p65L0p15_.yml
@@ -1,3 +1,3 @@
 info: {}
-name: sky130_fd_pr__rf_pfet_0_860121b8
+name: sky130_fd_pr__rf_pfet_01v8_bM02W1p65L0p15
 settings: {}

--- a/tests/test_components/test_pdk_settings_sky130_fd_pr__rf_pfet_01v8_bM02W1p65L0p18_.yml
+++ b/tests/test_components/test_pdk_settings_sky130_fd_pr__rf_pfet_01v8_bM02W1p65L0p18_.yml
@@ -1,3 +1,3 @@
 info: {}
-name: sky130_fd_pr__rf_pfet_0_287d6229
+name: sky130_fd_pr__rf_pfet_01v8_bM02W1p65L0p18
 settings: {}

--- a/tests/test_components/test_pdk_settings_sky130_fd_pr__rf_pfet_01v8_bM02W1p65L0p25_.yml
+++ b/tests/test_components/test_pdk_settings_sky130_fd_pr__rf_pfet_01v8_bM02W1p65L0p25_.yml
@@ -1,3 +1,3 @@
 info: {}
-name: sky130_fd_pr__rf_pfet_0_da70d08b
+name: sky130_fd_pr__rf_pfet_01v8_bM02W1p65L0p25
 settings: {}

--- a/tests/test_components/test_pdk_settings_sky130_fd_pr__rf_pfet_01v8_bM02W3p00L0p15_.yml
+++ b/tests/test_components/test_pdk_settings_sky130_fd_pr__rf_pfet_01v8_bM02W3p00L0p15_.yml
@@ -1,3 +1,3 @@
 info: {}
-name: sky130_fd_pr__rf_pfet_0_98d8ea84
+name: sky130_fd_pr__rf_pfet_01v8_bM02W3p00L0p15
 settings: {}

--- a/tests/test_components/test_pdk_settings_sky130_fd_pr__rf_pfet_01v8_bM02W3p00L0p18_.yml
+++ b/tests/test_components/test_pdk_settings_sky130_fd_pr__rf_pfet_01v8_bM02W3p00L0p18_.yml
@@ -1,3 +1,3 @@
 info: {}
-name: sky130_fd_pr__rf_pfet_0_f2991288
+name: sky130_fd_pr__rf_pfet_01v8_bM02W3p00L0p18
 settings: {}

--- a/tests/test_components/test_pdk_settings_sky130_fd_pr__rf_pfet_01v8_bM02W3p00L0p25_.yml
+++ b/tests/test_components/test_pdk_settings_sky130_fd_pr__rf_pfet_01v8_bM02W3p00L0p25_.yml
@@ -1,3 +1,3 @@
 info: {}
-name: sky130_fd_pr__rf_pfet_0_08b96249
+name: sky130_fd_pr__rf_pfet_01v8_bM02W3p00L0p25
 settings: {}

--- a/tests/test_components/test_pdk_settings_sky130_fd_pr__rf_pfet_01v8_bM02W5p00L0p15_.yml
+++ b/tests/test_components/test_pdk_settings_sky130_fd_pr__rf_pfet_01v8_bM02W5p00L0p15_.yml
@@ -1,3 +1,3 @@
 info: {}
-name: sky130_fd_pr__rf_pfet_0_527273d2
+name: sky130_fd_pr__rf_pfet_01v8_bM02W5p00L0p15
 settings: {}

--- a/tests/test_components/test_pdk_settings_sky130_fd_pr__rf_pfet_01v8_bM02W5p00L0p18_.yml
+++ b/tests/test_components/test_pdk_settings_sky130_fd_pr__rf_pfet_01v8_bM02W5p00L0p18_.yml
@@ -1,3 +1,3 @@
 info: {}
-name: sky130_fd_pr__rf_pfet_0_2c0da40f
+name: sky130_fd_pr__rf_pfet_01v8_bM02W5p00L0p18
 settings: {}

--- a/tests/test_components/test_pdk_settings_sky130_fd_pr__rf_pfet_01v8_bM02W5p00L0p25_.yml
+++ b/tests/test_components/test_pdk_settings_sky130_fd_pr__rf_pfet_01v8_bM02W5p00L0p25_.yml
@@ -1,3 +1,3 @@
 info: {}
-name: sky130_fd_pr__rf_pfet_0_4d6348ee
+name: sky130_fd_pr__rf_pfet_01v8_bM02W5p00L0p25
 settings: {}

--- a/tests/test_components/test_pdk_settings_sky130_fd_pr__rf_pfet_01v8_bM04W1p65L0p15_.yml
+++ b/tests/test_components/test_pdk_settings_sky130_fd_pr__rf_pfet_01v8_bM04W1p65L0p15_.yml
@@ -1,3 +1,3 @@
 info: {}
-name: sky130_fd_pr__rf_pfet_0_c87c2193
+name: sky130_fd_pr__rf_pfet_01v8_bM04W1p65L0p15
 settings: {}

--- a/tests/test_components/test_pdk_settings_sky130_fd_pr__rf_pfet_01v8_bM04W1p65L0p18_.yml
+++ b/tests/test_components/test_pdk_settings_sky130_fd_pr__rf_pfet_01v8_bM04W1p65L0p18_.yml
@@ -1,3 +1,3 @@
 info: {}
-name: sky130_fd_pr__rf_pfet_0_6895e299
+name: sky130_fd_pr__rf_pfet_01v8_bM04W1p65L0p18
 settings: {}

--- a/tests/test_components/test_pdk_settings_sky130_fd_pr__rf_pfet_01v8_bM04W1p65L0p25_.yml
+++ b/tests/test_components/test_pdk_settings_sky130_fd_pr__rf_pfet_01v8_bM04W1p65L0p25_.yml
@@ -1,3 +1,3 @@
 info: {}
-name: sky130_fd_pr__rf_pfet_0_d5b54ddf
+name: sky130_fd_pr__rf_pfet_01v8_bM04W1p65L0p25
 settings: {}

--- a/tests/test_components/test_pdk_settings_sky130_fd_pr__rf_pfet_01v8_bM04W3p00L0p15_.yml
+++ b/tests/test_components/test_pdk_settings_sky130_fd_pr__rf_pfet_01v8_bM04W3p00L0p15_.yml
@@ -1,3 +1,3 @@
 info: {}
-name: sky130_fd_pr__rf_pfet_0_a605566d
+name: sky130_fd_pr__rf_pfet_01v8_bM04W3p00L0p15
 settings: {}

--- a/tests/test_components/test_pdk_settings_sky130_fd_pr__rf_pfet_01v8_bM04W3p00L0p18_.yml
+++ b/tests/test_components/test_pdk_settings_sky130_fd_pr__rf_pfet_01v8_bM04W3p00L0p18_.yml
@@ -1,3 +1,3 @@
 info: {}
-name: sky130_fd_pr__rf_pfet_0_6b9962b0
+name: sky130_fd_pr__rf_pfet_01v8_bM04W3p00L0p18
 settings: {}

--- a/tests/test_components/test_pdk_settings_sky130_fd_pr__rf_pfet_01v8_bM04W3p00L0p25_.yml
+++ b/tests/test_components/test_pdk_settings_sky130_fd_pr__rf_pfet_01v8_bM04W3p00L0p25_.yml
@@ -1,3 +1,3 @@
 info: {}
-name: sky130_fd_pr__rf_pfet_0_83eb3c8d
+name: sky130_fd_pr__rf_pfet_01v8_bM04W3p00L0p25
 settings: {}

--- a/tests/test_components/test_pdk_settings_sky130_fd_pr__rf_pfet_01v8_bM04W5p00L0p15_.yml
+++ b/tests/test_components/test_pdk_settings_sky130_fd_pr__rf_pfet_01v8_bM04W5p00L0p15_.yml
@@ -1,3 +1,3 @@
 info: {}
-name: sky130_fd_pr__rf_pfet_0_5fb01024
+name: sky130_fd_pr__rf_pfet_01v8_bM04W5p00L0p15
 settings: {}

--- a/tests/test_components/test_pdk_settings_sky130_fd_pr__rf_pfet_01v8_bM04W5p00L0p18_.yml
+++ b/tests/test_components/test_pdk_settings_sky130_fd_pr__rf_pfet_01v8_bM04W5p00L0p18_.yml
@@ -1,3 +1,3 @@
 info: {}
-name: sky130_fd_pr__rf_pfet_0_c5584924
+name: sky130_fd_pr__rf_pfet_01v8_bM04W5p00L0p18
 settings: {}

--- a/tests/test_components/test_pdk_settings_sky130_fd_pr__rf_pfet_01v8_bM04W5p00L0p25_.yml
+++ b/tests/test_components/test_pdk_settings_sky130_fd_pr__rf_pfet_01v8_bM04W5p00L0p25_.yml
@@ -1,3 +1,3 @@
 info: {}
-name: sky130_fd_pr__rf_pfet_0_4d160b8a
+name: sky130_fd_pr__rf_pfet_01v8_bM04W5p00L0p25
 settings: {}

--- a/tests/test_components/test_pdk_settings_sky130_fd_pr__rf_pfet_01v8_hcM04W3p00L0p15_.yml
+++ b/tests/test_components/test_pdk_settings_sky130_fd_pr__rf_pfet_01v8_hcM04W3p00L0p15_.yml
@@ -1,3 +1,3 @@
 info: {}
-name: sky130_fd_pr__rf_pfet_0_378dd7c5
+name: sky130_fd_pr__rf_pfet_01v8_hcM04W3p00L0p15
 settings: {}

--- a/tests/test_components/test_pdk_settings_sky130_fd_pr__rf_pfet_01v8_hcM04W5p00L0p15_.yml
+++ b/tests/test_components/test_pdk_settings_sky130_fd_pr__rf_pfet_01v8_hcM04W5p00L0p15_.yml
@@ -1,3 +1,3 @@
 info: {}
-name: sky130_fd_pr__rf_pfet_0_529c2a8b
+name: sky130_fd_pr__rf_pfet_01v8_hcM04W5p00L0p15
 settings: {}

--- a/tests/test_components/test_pdk_settings_sky130_fd_pr__rf_pfet_01v8_lvt_aM02W3p00L0p35_.yml
+++ b/tests/test_components/test_pdk_settings_sky130_fd_pr__rf_pfet_01v8_lvt_aM02W3p00L0p35_.yml
@@ -1,3 +1,3 @@
 info: {}
-name: sky130_fd_pr__rf_pfet_0_abe8e018
+name: sky130_fd_pr__rf_pfet_01v8_lvt_aM02W3p00L0p35
 settings: {}

--- a/tests/test_components/test_pdk_settings_sky130_fd_pr__rf_pfet_01v8_lvt_aM02W3p00L0p50_.yml
+++ b/tests/test_components/test_pdk_settings_sky130_fd_pr__rf_pfet_01v8_lvt_aM02W3p00L0p50_.yml
@@ -1,3 +1,3 @@
 info: {}
-name: sky130_fd_pr__rf_pfet_0_42cabdba
+name: sky130_fd_pr__rf_pfet_01v8_lvt_aM02W3p00L0p50
 settings: {}

--- a/tests/test_components/test_pdk_settings_sky130_fd_pr__rf_pfet_01v8_lvt_aM02W5p00L0p35_.yml
+++ b/tests/test_components/test_pdk_settings_sky130_fd_pr__rf_pfet_01v8_lvt_aM02W5p00L0p35_.yml
@@ -1,3 +1,3 @@
 info: {}
-name: sky130_fd_pr__rf_pfet_0_0d59e89e
+name: sky130_fd_pr__rf_pfet_01v8_lvt_aM02W5p00L0p35
 settings: {}

--- a/tests/test_components/test_pdk_settings_sky130_fd_pr__rf_pfet_01v8_lvt_aM02W5p00L0p50_.yml
+++ b/tests/test_components/test_pdk_settings_sky130_fd_pr__rf_pfet_01v8_lvt_aM02W5p00L0p50_.yml
@@ -1,3 +1,3 @@
 info: {}
-name: sky130_fd_pr__rf_pfet_0_f5d77410
+name: sky130_fd_pr__rf_pfet_01v8_lvt_aM02W5p00L0p50
 settings: {}

--- a/tests/test_components/test_pdk_settings_sky130_fd_pr__rf_pfet_01v8_lvt_aM04W3p00L0p35_.yml
+++ b/tests/test_components/test_pdk_settings_sky130_fd_pr__rf_pfet_01v8_lvt_aM04W3p00L0p35_.yml
@@ -1,3 +1,3 @@
 info: {}
-name: sky130_fd_pr__rf_pfet_0_96a16548
+name: sky130_fd_pr__rf_pfet_01v8_lvt_aM04W3p00L0p35
 settings: {}

--- a/tests/test_components/test_pdk_settings_sky130_fd_pr__rf_pfet_01v8_lvt_aM04W3p00L0p50_.yml
+++ b/tests/test_components/test_pdk_settings_sky130_fd_pr__rf_pfet_01v8_lvt_aM04W3p00L0p50_.yml
@@ -1,3 +1,3 @@
 info: {}
-name: sky130_fd_pr__rf_pfet_0_e25c04f9
+name: sky130_fd_pr__rf_pfet_01v8_lvt_aM04W3p00L0p50
 settings: {}

--- a/tests/test_components/test_pdk_settings_sky130_fd_pr__rf_pfet_01v8_lvt_aM04W5p00L0p35_.yml
+++ b/tests/test_components/test_pdk_settings_sky130_fd_pr__rf_pfet_01v8_lvt_aM04W5p00L0p35_.yml
@@ -1,3 +1,3 @@
 info: {}
-name: sky130_fd_pr__rf_pfet_0_86f6cd30
+name: sky130_fd_pr__rf_pfet_01v8_lvt_aM04W5p00L0p35
 settings: {}

--- a/tests/test_components/test_pdk_settings_sky130_fd_pr__rf_pfet_01v8_lvt_aM04W5p00L0p50_.yml
+++ b/tests/test_components/test_pdk_settings_sky130_fd_pr__rf_pfet_01v8_lvt_aM04W5p00L0p50_.yml
@@ -1,3 +1,3 @@
 info: {}
-name: sky130_fd_pr__rf_pfet_0_27fb147c
+name: sky130_fd_pr__rf_pfet_01v8_lvt_aM04W5p00L0p50
 settings: {}

--- a/tests/test_components/test_pdk_settings_sky130_fd_pr__rf_pfet_01v8_mcM04W3p00L0p15_.yml
+++ b/tests/test_components/test_pdk_settings_sky130_fd_pr__rf_pfet_01v8_mcM04W3p00L0p15_.yml
@@ -1,3 +1,3 @@
 info: {}
-name: sky130_fd_pr__rf_pfet_0_17370416
+name: sky130_fd_pr__rf_pfet_01v8_mcM04W3p00L0p15
 settings: {}

--- a/tests/test_components/test_pdk_settings_sky130_fd_pr__rf_pfet_01v8_mcM04W5p00L0p15_.yml
+++ b/tests/test_components/test_pdk_settings_sky130_fd_pr__rf_pfet_01v8_mcM04W5p00L0p15_.yml
@@ -1,3 +1,3 @@
 info: {}
-name: sky130_fd_pr__rf_pfet_0_f485aa28
+name: sky130_fd_pr__rf_pfet_01v8_mcM04W5p00L0p15
 settings: {}

--- a/tests/test_components/test_pdk_settings_sky130_fd_pr__rf_pfet_01v8_mvt_aF02W0p84L0p15_.yml
+++ b/tests/test_components/test_pdk_settings_sky130_fd_pr__rf_pfet_01v8_mvt_aF02W0p84L0p15_.yml
@@ -1,3 +1,3 @@
 info: {}
-name: sky130_fd_pr__rf_pfet_0_be8db44f
+name: sky130_fd_pr__rf_pfet_01v8_mvt_aF02W0p84L0p15
 settings: {}

--- a/tests/test_components/test_pdk_settings_sky130_fd_pr__rf_pfet_20v0_withptap_.yml
+++ b/tests/test_components/test_pdk_settings_sky130_fd_pr__rf_pfet_20v0_withptap_.yml
@@ -1,3 +1,3 @@
 info: {}
-name: sky130_fd_pr__rf_pfet_2_d21d5338
+name: sky130_fd_pr__rf_pfet_20v0_withptap
 settings: {}

--- a/tests/test_components/test_pdk_settings_sky130_fd_pr__rf_pnp_05v5_W0p68L0p68_.yml
+++ b/tests/test_components/test_pdk_settings_sky130_fd_pr__rf_pnp_05v5_W0p68L0p68_.yml
@@ -1,3 +1,3 @@
 info: {}
-name: sky130_fd_pr__rf_pnp_05_d927f531
+name: sky130_fd_pr__rf_pnp_05v5_W0p68L0p68
 settings: {}

--- a/tests/test_components/test_pdk_settings_sky130_fd_pr__rf_pnp_05v5_W3p40L3p40_.yml
+++ b/tests/test_components/test_pdk_settings_sky130_fd_pr__rf_pnp_05v5_W3p40L3p40_.yml
@@ -1,3 +1,3 @@
 info: {}
-name: sky130_fd_pr__rf_pnp_05_eec846fe
+name: sky130_fd_pr__rf_pnp_05v5_W3p40L3p40
 settings: {}

--- a/tests/test_components/test_pdk_settings_sky130_fd_sc_hd__lpflow_bleeder_1_.yml
+++ b/tests/test_components/test_pdk_settings_sky130_fd_sc_hd__lpflow_bleeder_1_.yml
@@ -1,3 +1,3 @@
 info: {}
-name: sky130_fd_sc_hd__lpflow_201ba627
+name: sky130_fd_sc_hd__lpflow_bleeder_1
 settings: {}

--- a/tests/test_components/test_pdk_settings_sky130_fd_sc_hd__lpflow_clkbufkapwr_16_.yml
+++ b/tests/test_components/test_pdk_settings_sky130_fd_sc_hd__lpflow_clkbufkapwr_16_.yml
@@ -1,3 +1,3 @@
 info: {}
-name: sky130_fd_sc_hd__lpflow_874ef3e5
+name: sky130_fd_sc_hd__lpflow_clkbufkapwr_16
 settings: {}

--- a/tests/test_components/test_pdk_settings_sky130_fd_sc_hd__lpflow_clkbufkapwr_1_.yml
+++ b/tests/test_components/test_pdk_settings_sky130_fd_sc_hd__lpflow_clkbufkapwr_1_.yml
@@ -1,3 +1,3 @@
 info: {}
-name: sky130_fd_sc_hd__lpflow_5a13adb8
+name: sky130_fd_sc_hd__lpflow_clkbufkapwr_1
 settings: {}

--- a/tests/test_components/test_pdk_settings_sky130_fd_sc_hd__lpflow_clkbufkapwr_2_.yml
+++ b/tests/test_components/test_pdk_settings_sky130_fd_sc_hd__lpflow_clkbufkapwr_2_.yml
@@ -1,3 +1,3 @@
 info: {}
-name: sky130_fd_sc_hd__lpflow_ae1e1bce
+name: sky130_fd_sc_hd__lpflow_clkbufkapwr_2
 settings: {}

--- a/tests/test_components/test_pdk_settings_sky130_fd_sc_hd__lpflow_clkbufkapwr_4_.yml
+++ b/tests/test_components/test_pdk_settings_sky130_fd_sc_hd__lpflow_clkbufkapwr_4_.yml
@@ -1,3 +1,3 @@
 info: {}
-name: sky130_fd_sc_hd__lpflow_9fc2c14c
+name: sky130_fd_sc_hd__lpflow_clkbufkapwr_4
 settings: {}

--- a/tests/test_components/test_pdk_settings_sky130_fd_sc_hd__lpflow_clkbufkapwr_8_.yml
+++ b/tests/test_components/test_pdk_settings_sky130_fd_sc_hd__lpflow_clkbufkapwr_8_.yml
@@ -1,3 +1,3 @@
 info: {}
-name: sky130_fd_sc_hd__lpflow_9b0ab1cc
+name: sky130_fd_sc_hd__lpflow_clkbufkapwr_8
 settings: {}

--- a/tests/test_components/test_pdk_settings_sky130_fd_sc_hd__lpflow_clkinvkapwr_16_.yml
+++ b/tests/test_components/test_pdk_settings_sky130_fd_sc_hd__lpflow_clkinvkapwr_16_.yml
@@ -1,3 +1,3 @@
 info: {}
-name: sky130_fd_sc_hd__lpflow_7cd960df
+name: sky130_fd_sc_hd__lpflow_clkinvkapwr_16
 settings: {}

--- a/tests/test_components/test_pdk_settings_sky130_fd_sc_hd__lpflow_clkinvkapwr_1_.yml
+++ b/tests/test_components/test_pdk_settings_sky130_fd_sc_hd__lpflow_clkinvkapwr_1_.yml
@@ -1,3 +1,3 @@
 info: {}
-name: sky130_fd_sc_hd__lpflow_77dc2ca2
+name: sky130_fd_sc_hd__lpflow_clkinvkapwr_1
 settings: {}

--- a/tests/test_components/test_pdk_settings_sky130_fd_sc_hd__lpflow_clkinvkapwr_2_.yml
+++ b/tests/test_components/test_pdk_settings_sky130_fd_sc_hd__lpflow_clkinvkapwr_2_.yml
@@ -1,3 +1,3 @@
 info: {}
-name: sky130_fd_sc_hd__lpflow_73f99440
+name: sky130_fd_sc_hd__lpflow_clkinvkapwr_2
 settings: {}

--- a/tests/test_components/test_pdk_settings_sky130_fd_sc_hd__lpflow_clkinvkapwr_4_.yml
+++ b/tests/test_components/test_pdk_settings_sky130_fd_sc_hd__lpflow_clkinvkapwr_4_.yml
@@ -1,3 +1,3 @@
 info: {}
-name: sky130_fd_sc_hd__lpflow_89753a68
+name: sky130_fd_sc_hd__lpflow_clkinvkapwr_4
 settings: {}

--- a/tests/test_components/test_pdk_settings_sky130_fd_sc_hd__lpflow_clkinvkapwr_8_.yml
+++ b/tests/test_components/test_pdk_settings_sky130_fd_sc_hd__lpflow_clkinvkapwr_8_.yml
@@ -1,3 +1,3 @@
 info: {}
-name: sky130_fd_sc_hd__lpflow_bd315fbf
+name: sky130_fd_sc_hd__lpflow_clkinvkapwr_8
 settings: {}

--- a/tests/test_components/test_pdk_settings_sky130_fd_sc_hd__lpflow_decapkapwr_12_.yml
+++ b/tests/test_components/test_pdk_settings_sky130_fd_sc_hd__lpflow_decapkapwr_12_.yml
@@ -1,3 +1,3 @@
 info: {}
-name: sky130_fd_sc_hd__lpflow_69544c28
+name: sky130_fd_sc_hd__lpflow_decapkapwr_12
 settings: {}

--- a/tests/test_components/test_pdk_settings_sky130_fd_sc_hd__lpflow_decapkapwr_3_.yml
+++ b/tests/test_components/test_pdk_settings_sky130_fd_sc_hd__lpflow_decapkapwr_3_.yml
@@ -1,3 +1,3 @@
 info: {}
-name: sky130_fd_sc_hd__lpflow_fc47cbd5
+name: sky130_fd_sc_hd__lpflow_decapkapwr_3
 settings: {}

--- a/tests/test_components/test_pdk_settings_sky130_fd_sc_hd__lpflow_decapkapwr_4_.yml
+++ b/tests/test_components/test_pdk_settings_sky130_fd_sc_hd__lpflow_decapkapwr_4_.yml
@@ -1,3 +1,3 @@
 info: {}
-name: sky130_fd_sc_hd__lpflow_fe905c6a
+name: sky130_fd_sc_hd__lpflow_decapkapwr_4
 settings: {}

--- a/tests/test_components/test_pdk_settings_sky130_fd_sc_hd__lpflow_decapkapwr_6_.yml
+++ b/tests/test_components/test_pdk_settings_sky130_fd_sc_hd__lpflow_decapkapwr_6_.yml
@@ -1,3 +1,3 @@
 info: {}
-name: sky130_fd_sc_hd__lpflow_7a6b62f4
+name: sky130_fd_sc_hd__lpflow_decapkapwr_6
 settings: {}

--- a/tests/test_components/test_pdk_settings_sky130_fd_sc_hd__lpflow_decapkapwr_8_.yml
+++ b/tests/test_components/test_pdk_settings_sky130_fd_sc_hd__lpflow_decapkapwr_8_.yml
@@ -1,3 +1,3 @@
 info: {}
-name: sky130_fd_sc_hd__lpflow_2deb31ad
+name: sky130_fd_sc_hd__lpflow_decapkapwr_8
 settings: {}

--- a/tests/test_components/test_pdk_settings_sky130_fd_sc_hd__lpflow_inputiso0n_1_.yml
+++ b/tests/test_components/test_pdk_settings_sky130_fd_sc_hd__lpflow_inputiso0n_1_.yml
@@ -1,3 +1,3 @@
 info: {}
-name: sky130_fd_sc_hd__lpflow_99403f12
+name: sky130_fd_sc_hd__lpflow_inputiso0n_1
 settings: {}

--- a/tests/test_components/test_pdk_settings_sky130_fd_sc_hd__lpflow_inputiso0p_1_.yml
+++ b/tests/test_components/test_pdk_settings_sky130_fd_sc_hd__lpflow_inputiso0p_1_.yml
@@ -1,3 +1,3 @@
 info: {}
-name: sky130_fd_sc_hd__lpflow_44946e8b
+name: sky130_fd_sc_hd__lpflow_inputiso0p_1
 settings: {}

--- a/tests/test_components/test_pdk_settings_sky130_fd_sc_hd__lpflow_inputiso1n_1_.yml
+++ b/tests/test_components/test_pdk_settings_sky130_fd_sc_hd__lpflow_inputiso1n_1_.yml
@@ -1,3 +1,3 @@
 info: {}
-name: sky130_fd_sc_hd__lpflow_701da8f2
+name: sky130_fd_sc_hd__lpflow_inputiso1n_1
 settings: {}

--- a/tests/test_components/test_pdk_settings_sky130_fd_sc_hd__lpflow_inputiso1p_1_.yml
+++ b/tests/test_components/test_pdk_settings_sky130_fd_sc_hd__lpflow_inputiso1p_1_.yml
@@ -1,3 +1,3 @@
 info: {}
-name: sky130_fd_sc_hd__lpflow_96cbadf5
+name: sky130_fd_sc_hd__lpflow_inputiso1p_1
 settings: {}

--- a/tests/test_components/test_pdk_settings_sky130_fd_sc_hd__lpflow_inputisolatch_1_.yml
+++ b/tests/test_components/test_pdk_settings_sky130_fd_sc_hd__lpflow_inputisolatch_1_.yml
@@ -1,3 +1,3 @@
 info: {}
-name: sky130_fd_sc_hd__lpflow_6c1666c3
+name: sky130_fd_sc_hd__lpflow_inputisolatch_1
 settings: {}

--- a/tests/test_components/test_pdk_settings_sky130_fd_sc_hd__lpflow_isobufsrc_16_.yml
+++ b/tests/test_components/test_pdk_settings_sky130_fd_sc_hd__lpflow_isobufsrc_16_.yml
@@ -1,3 +1,3 @@
 info: {}
-name: sky130_fd_sc_hd__lpflow_5a0016c3
+name: sky130_fd_sc_hd__lpflow_isobufsrc_16
 settings: {}

--- a/tests/test_components/test_pdk_settings_sky130_fd_sc_hd__lpflow_isobufsrc_1_.yml
+++ b/tests/test_components/test_pdk_settings_sky130_fd_sc_hd__lpflow_isobufsrc_1_.yml
@@ -1,3 +1,3 @@
 info: {}
-name: sky130_fd_sc_hd__lpflow_c8127a55
+name: sky130_fd_sc_hd__lpflow_isobufsrc_1
 settings: {}

--- a/tests/test_components/test_pdk_settings_sky130_fd_sc_hd__lpflow_isobufsrc_2_.yml
+++ b/tests/test_components/test_pdk_settings_sky130_fd_sc_hd__lpflow_isobufsrc_2_.yml
@@ -1,3 +1,3 @@
 info: {}
-name: sky130_fd_sc_hd__lpflow_663ba85c
+name: sky130_fd_sc_hd__lpflow_isobufsrc_2
 settings: {}

--- a/tests/test_components/test_pdk_settings_sky130_fd_sc_hd__lpflow_isobufsrc_4_.yml
+++ b/tests/test_components/test_pdk_settings_sky130_fd_sc_hd__lpflow_isobufsrc_4_.yml
@@ -1,3 +1,3 @@
 info: {}
-name: sky130_fd_sc_hd__lpflow_d878ea4d
+name: sky130_fd_sc_hd__lpflow_isobufsrc_4
 settings: {}

--- a/tests/test_components/test_pdk_settings_sky130_fd_sc_hd__lpflow_isobufsrc_8_.yml
+++ b/tests/test_components/test_pdk_settings_sky130_fd_sc_hd__lpflow_isobufsrc_8_.yml
@@ -1,3 +1,3 @@
 info: {}
-name: sky130_fd_sc_hd__lpflow_914340b3
+name: sky130_fd_sc_hd__lpflow_isobufsrc_8
 settings: {}

--- a/tests/test_components/test_pdk_settings_sky130_fd_sc_hd__lpflow_isobufsrckapwr_16_.yml
+++ b/tests/test_components/test_pdk_settings_sky130_fd_sc_hd__lpflow_isobufsrckapwr_16_.yml
@@ -1,3 +1,3 @@
 info: {}
-name: sky130_fd_sc_hd__lpflow_1b5abbb4
+name: sky130_fd_sc_hd__lpflow_isobufsrckapwr_16
 settings: {}

--- a/tests/test_components/test_pdk_settings_sky130_fd_sc_hd__lpflow_lsbuf_lh_hl_isowell_tap_1_.yml
+++ b/tests/test_components/test_pdk_settings_sky130_fd_sc_hd__lpflow_lsbuf_lh_hl_isowell_tap_1_.yml
@@ -1,3 +1,3 @@
 info: {}
-name: sky130_fd_sc_hd__lpflow_e58719ff
+name: sky130_fd_sc_hd__lpflow_lsbuf_lh_hl_isowell_tap_1
 settings: {}

--- a/tests/test_components/test_pdk_settings_sky130_fd_sc_hd__lpflow_lsbuf_lh_hl_isowell_tap_2_.yml
+++ b/tests/test_components/test_pdk_settings_sky130_fd_sc_hd__lpflow_lsbuf_lh_hl_isowell_tap_2_.yml
@@ -1,3 +1,3 @@
 info: {}
-name: sky130_fd_sc_hd__lpflow_db084712
+name: sky130_fd_sc_hd__lpflow_lsbuf_lh_hl_isowell_tap_2
 settings: {}

--- a/tests/test_components/test_pdk_settings_sky130_fd_sc_hd__lpflow_lsbuf_lh_hl_isowell_tap_4_.yml
+++ b/tests/test_components/test_pdk_settings_sky130_fd_sc_hd__lpflow_lsbuf_lh_hl_isowell_tap_4_.yml
@@ -1,3 +1,3 @@
 info: {}
-name: sky130_fd_sc_hd__lpflow_956919ee
+name: sky130_fd_sc_hd__lpflow_lsbuf_lh_hl_isowell_tap_4
 settings: {}

--- a/tests/test_components/test_pdk_settings_sky130_fd_sc_hd__lpflow_lsbuf_lh_isowell_4_.yml
+++ b/tests/test_components/test_pdk_settings_sky130_fd_sc_hd__lpflow_lsbuf_lh_isowell_4_.yml
@@ -1,3 +1,3 @@
 info: {}
-name: sky130_fd_sc_hd__lpflow_c800add7
+name: sky130_fd_sc_hd__lpflow_lsbuf_lh_isowell_4
 settings: {}

--- a/tests/test_components/test_pdk_settings_sky130_fd_sc_hd__lpflow_lsbuf_lh_isowell_tap_1_.yml
+++ b/tests/test_components/test_pdk_settings_sky130_fd_sc_hd__lpflow_lsbuf_lh_isowell_tap_1_.yml
@@ -1,3 +1,3 @@
 info: {}
-name: sky130_fd_sc_hd__lpflow_56b7867c
+name: sky130_fd_sc_hd__lpflow_lsbuf_lh_isowell_tap_1
 settings: {}

--- a/tests/test_components/test_pdk_settings_sky130_fd_sc_hd__lpflow_lsbuf_lh_isowell_tap_2_.yml
+++ b/tests/test_components/test_pdk_settings_sky130_fd_sc_hd__lpflow_lsbuf_lh_isowell_tap_2_.yml
@@ -1,3 +1,3 @@
 info: {}
-name: sky130_fd_sc_hd__lpflow_6a373c09
+name: sky130_fd_sc_hd__lpflow_lsbuf_lh_isowell_tap_2
 settings: {}

--- a/tests/test_components/test_pdk_settings_sky130_fd_sc_hd__lpflow_lsbuf_lh_isowell_tap_4_.yml
+++ b/tests/test_components/test_pdk_settings_sky130_fd_sc_hd__lpflow_lsbuf_lh_isowell_tap_4_.yml
@@ -1,3 +1,3 @@
 info: {}
-name: sky130_fd_sc_hd__lpflow_2db8b44b
+name: sky130_fd_sc_hd__lpflow_lsbuf_lh_isowell_tap_4
 settings: {}

--- a/tests/test_components/test_pdk_settings_straight_metal1_.yml
+++ b/tests/test_components/test_pdk_settings_straight_metal1_.yml
@@ -1,0 +1,11 @@
+info:
+  length: 10
+  route_info_length: 10
+  route_info_metal1_length: 10
+  route_info_type: metal1
+  route_info_weight: 10
+  width: 0.2
+name: straight_metal1_L10_CSmetal1_WNone
+settings:
+  cross_section: metal1
+  length: 10

--- a/tests/test_components/test_pdk_settings_straight_metal2_.yml
+++ b/tests/test_components/test_pdk_settings_straight_metal2_.yml
@@ -1,0 +1,11 @@
+info:
+  length: 10
+  route_info_length: 10
+  route_info_metal2_length: 10
+  route_info_type: metal2
+  route_info_weight: 10
+  width: 0.2
+name: straight_metal2_L10_CSmetal2_WNone
+settings:
+  cross_section: metal2
+  length: 10

--- a/tests/test_components/test_pdk_settings_via_generator_.yml
+++ b/tests/test_components/test_pdk_settings_via_generator_.yml
@@ -1,5 +1,5 @@
 info: {}
-name: via_generator_W1_L1_VS0_4e5a27c8
+name: via_generator_W1_L1_VS0p17_0p17_VL66_44_VE0p06_0p06_VS0p17_0p17
 settings:
   length: 1
   via_enclosure:

--- a/tests/test_components/test_pdk_settings_wire_corner45_.yml
+++ b/tests/test_components/test_pdk_settings_wire_corner45_.yml
@@ -1,0 +1,7 @@
+info:
+  length: 14.142
+name: wire_corner45_CSmetal2_R10_WNone_LNone_WCPTrue
+settings:
+  cross_section: metal2
+  radius: 10
+  with_corner90_ports: true

--- a/tests/test_components/test_pdk_settings_wire_corner_.yml
+++ b/tests/test_components/test_pdk_settings_wire_corner_.yml
@@ -1,0 +1,6 @@
+info:
+  dy: 0.2
+  length: 0.2
+name: wire_corner_CSmetal2_WNone
+settings:
+  cross_section: metal2


### PR DESCRIPTION
- **Improve type annotations display in documentation**
- **fix readme**

## Summary by Sourcery

Improve documentation by enhancing Sphinx type hint display and alias mappings, correct README clone URL, and update gdsfactory dependency version

Bug Fixes:
- Fix clone URL in README to point to gdsfactory/skywater130 repository

Enhancements:
- Configure Sphinx to display type hints as descriptions with short formatting and unqualified names
- Extend autodoc_type_aliases mapping for common types to simplify annotation display

Build:
- Bump gdsfactory dependency from 9.8.0 to 9.14.2