### PR TITLE
Add uv.lock exclude to pretty-format-toml

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -7,10 +7,11 @@ repos:
       - id: requirements-txt-fixer
 
   - repo: https://github.com/macisamuele/language-formatters-pre-commit-hooks
-    rev: v2.14.0
+    rev: v2.16.0
     hooks:
       - id: pretty-format-toml
         args: [--autofix]
+        exclude: ^uv\.lock$
   - repo: https://github.com/kynan/nbstripout
     rev: 0.8.1
     hooks:


### PR DESCRIPTION
## Summary
- Bump `language-formatters-pre-commit-hooks` to v2.16.0
- Add `exclude: ^uv\.lock$` to `pretty-format-toml` hook

## Test plan
- [ ] Verify pre-commit hooks still pass

## Summary by Sourcery

Build:
- Bump language-formatters-pre-commit-hooks pre-commit hook to v2.16.0 and configure pretty-format-toml to ignore uv.lock files.