### PR TITLE
docs: group cells by category (digital, analog, RF, ...)

### DIFF
--- a/docs/components.rst
+++ b/docs/components.rst
@@ -1,9 +1,579 @@
-
-
 Cells
-=============================
+=====
 
-.. currentmodule:: sky130.cells
+Fixed (GDS-backed) cells available in the PDK, grouped by function.
+
+Digital standard cells (sky130_fd_sc_hd)
+----------------------------------------
+
+High-density digital standard-cell library.  Cells are grouped by
+logical function.  The trailing ``_N`` in each name encodes the
+drive strength.
+
+Inverters
+^^^^^^^^^
+
+.. currentmodule:: sky130.components
+
+.. autosummary::
+   :toctree: _autosummary/
+
+   sky130_fd_sc_hd__einvn_0
+   sky130_fd_sc_hd__einvn_1
+   sky130_fd_sc_hd__einvn_2
+   sky130_fd_sc_hd__einvn_4
+   sky130_fd_sc_hd__einvn_8
+   sky130_fd_sc_hd__einvp_1
+   sky130_fd_sc_hd__einvp_2
+   sky130_fd_sc_hd__einvp_4
+   sky130_fd_sc_hd__einvp_8
+   sky130_fd_sc_hd__inv_1
+   sky130_fd_sc_hd__inv_12
+   sky130_fd_sc_hd__inv_16
+   sky130_fd_sc_hd__inv_2
+   sky130_fd_sc_hd__inv_4
+   sky130_fd_sc_hd__inv_6
+   sky130_fd_sc_hd__inv_8
+
+Buffers
+^^^^^^^
+
+.. currentmodule:: sky130.components
+
+.. autosummary::
+   :toctree: _autosummary/
+
+   sky130_fd_sc_hd__buf_1
+   sky130_fd_sc_hd__buf_12
+   sky130_fd_sc_hd__buf_16
+   sky130_fd_sc_hd__buf_2
+   sky130_fd_sc_hd__buf_4
+   sky130_fd_sc_hd__buf_6
+   sky130_fd_sc_hd__buf_8
+   sky130_fd_sc_hd__bufbuf_16
+   sky130_fd_sc_hd__bufbuf_8
+   sky130_fd_sc_hd__bufinv_16
+   sky130_fd_sc_hd__bufinv_8
+   sky130_fd_sc_hd__ebufn_1
+   sky130_fd_sc_hd__ebufn_2
+   sky130_fd_sc_hd__ebufn_4
+   sky130_fd_sc_hd__ebufn_8
+
+Clock
+^^^^^
+
+.. currentmodule:: sky130.components
+
+.. autosummary::
+   :toctree: _autosummary/
+
+   sky130_fd_sc_hd__clkbuf_1
+   sky130_fd_sc_hd__clkbuf_16
+   sky130_fd_sc_hd__clkbuf_2
+   sky130_fd_sc_hd__clkbuf_4
+   sky130_fd_sc_hd__clkbuf_8
+   sky130_fd_sc_hd__clkdlybuf4s15_1
+   sky130_fd_sc_hd__clkdlybuf4s15_2
+   sky130_fd_sc_hd__clkdlybuf4s18_1
+   sky130_fd_sc_hd__clkdlybuf4s18_2
+   sky130_fd_sc_hd__clkdlybuf4s25_1
+   sky130_fd_sc_hd__clkdlybuf4s25_2
+   sky130_fd_sc_hd__clkdlybuf4s50_1
+   sky130_fd_sc_hd__clkdlybuf4s50_2
+   sky130_fd_sc_hd__clkinv_1
+   sky130_fd_sc_hd__clkinv_16
+   sky130_fd_sc_hd__clkinv_2
+   sky130_fd_sc_hd__clkinv_4
+   sky130_fd_sc_hd__clkinv_8
+   sky130_fd_sc_hd__clkinvlp_2
+   sky130_fd_sc_hd__clkinvlp_4
+
+AND / NAND
+^^^^^^^^^^
+
+.. currentmodule:: sky130.components
+
+.. autosummary::
+   :toctree: _autosummary/
+
+   sky130_fd_sc_hd__and2_0
+   sky130_fd_sc_hd__and2_1
+   sky130_fd_sc_hd__and2_2
+   sky130_fd_sc_hd__and2_4
+   sky130_fd_sc_hd__and2b_1
+   sky130_fd_sc_hd__and2b_2
+   sky130_fd_sc_hd__and2b_4
+   sky130_fd_sc_hd__and3_1
+   sky130_fd_sc_hd__and3_2
+   sky130_fd_sc_hd__and3_4
+   sky130_fd_sc_hd__and3b_1
+   sky130_fd_sc_hd__and3b_2
+   sky130_fd_sc_hd__and3b_4
+   sky130_fd_sc_hd__and4_1
+   sky130_fd_sc_hd__and4_2
+   sky130_fd_sc_hd__and4_4
+   sky130_fd_sc_hd__and4b_1
+   sky130_fd_sc_hd__and4b_2
+   sky130_fd_sc_hd__and4b_4
+   sky130_fd_sc_hd__and4bb_1
+   sky130_fd_sc_hd__and4bb_2
+   sky130_fd_sc_hd__and4bb_4
+   sky130_fd_sc_hd__nand2_1
+   sky130_fd_sc_hd__nand2_2
+   sky130_fd_sc_hd__nand2_4
+   sky130_fd_sc_hd__nand2_8
+   sky130_fd_sc_hd__nand2b_1
+   sky130_fd_sc_hd__nand2b_2
+   sky130_fd_sc_hd__nand2b_4
+   sky130_fd_sc_hd__nand3_1
+   sky130_fd_sc_hd__nand3_2
+   sky130_fd_sc_hd__nand3_4
+   sky130_fd_sc_hd__nand3b_1
+   sky130_fd_sc_hd__nand3b_2
+   sky130_fd_sc_hd__nand3b_4
+   sky130_fd_sc_hd__nand4_1
+   sky130_fd_sc_hd__nand4_2
+   sky130_fd_sc_hd__nand4_4
+   sky130_fd_sc_hd__nand4b_1
+   sky130_fd_sc_hd__nand4b_2
+   sky130_fd_sc_hd__nand4b_4
+   sky130_fd_sc_hd__nand4bb_1
+   sky130_fd_sc_hd__nand4bb_2
+   sky130_fd_sc_hd__nand4bb_4
+
+OR / NOR
+^^^^^^^^
+
+.. currentmodule:: sky130.components
+
+.. autosummary::
+   :toctree: _autosummary/
+
+   sky130_fd_sc_hd__nor2_1
+   sky130_fd_sc_hd__nor2_2
+   sky130_fd_sc_hd__nor2_4
+   sky130_fd_sc_hd__nor2_8
+   sky130_fd_sc_hd__nor2b_1
+   sky130_fd_sc_hd__nor2b_2
+   sky130_fd_sc_hd__nor2b_4
+   sky130_fd_sc_hd__nor3_1
+   sky130_fd_sc_hd__nor3_2
+   sky130_fd_sc_hd__nor3_4
+   sky130_fd_sc_hd__nor3b_1
+   sky130_fd_sc_hd__nor3b_2
+   sky130_fd_sc_hd__nor3b_4
+   sky130_fd_sc_hd__nor4_1
+   sky130_fd_sc_hd__nor4_2
+   sky130_fd_sc_hd__nor4_4
+   sky130_fd_sc_hd__nor4b_1
+   sky130_fd_sc_hd__nor4b_2
+   sky130_fd_sc_hd__nor4b_4
+   sky130_fd_sc_hd__nor4bb_1
+   sky130_fd_sc_hd__nor4bb_2
+   sky130_fd_sc_hd__nor4bb_4
+   sky130_fd_sc_hd__or2_0
+   sky130_fd_sc_hd__or2_1
+   sky130_fd_sc_hd__or2_2
+   sky130_fd_sc_hd__or2_4
+   sky130_fd_sc_hd__or2b_1
+   sky130_fd_sc_hd__or2b_2
+   sky130_fd_sc_hd__or2b_4
+   sky130_fd_sc_hd__or3_1
+   sky130_fd_sc_hd__or3_2
+   sky130_fd_sc_hd__or3_4
+   sky130_fd_sc_hd__or3b_1
+   sky130_fd_sc_hd__or3b_2
+   sky130_fd_sc_hd__or3b_4
+   sky130_fd_sc_hd__or4_1
+   sky130_fd_sc_hd__or4_2
+   sky130_fd_sc_hd__or4_4
+   sky130_fd_sc_hd__or4b_1
+   sky130_fd_sc_hd__or4b_2
+   sky130_fd_sc_hd__or4b_4
+   sky130_fd_sc_hd__or4bb_1
+   sky130_fd_sc_hd__or4bb_2
+   sky130_fd_sc_hd__or4bb_4
+
+XOR / XNOR
+^^^^^^^^^^
+
+.. currentmodule:: sky130.components
+
+.. autosummary::
+   :toctree: _autosummary/
+
+   sky130_fd_sc_hd__xnor2_1
+   sky130_fd_sc_hd__xnor2_2
+   sky130_fd_sc_hd__xnor2_4
+   sky130_fd_sc_hd__xnor3_1
+   sky130_fd_sc_hd__xnor3_2
+   sky130_fd_sc_hd__xnor3_4
+   sky130_fd_sc_hd__xor2_1
+   sky130_fd_sc_hd__xor2_2
+   sky130_fd_sc_hd__xor2_4
+   sky130_fd_sc_hd__xor3_1
+   sky130_fd_sc_hd__xor3_2
+   sky130_fd_sc_hd__xor3_4
+
+Multiplexers
+^^^^^^^^^^^^
+
+.. currentmodule:: sky130.components
+
+.. autosummary::
+   :toctree: _autosummary/
+
+   sky130_fd_sc_hd__mux2_1
+   sky130_fd_sc_hd__mux2_2
+   sky130_fd_sc_hd__mux2_4
+   sky130_fd_sc_hd__mux2_8
+   sky130_fd_sc_hd__mux2i_1
+   sky130_fd_sc_hd__mux2i_2
+   sky130_fd_sc_hd__mux2i_4
+   sky130_fd_sc_hd__mux4_1
+   sky130_fd_sc_hd__mux4_2
+   sky130_fd_sc_hd__mux4_4
+
+Arithmetic (adders / majority)
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+.. currentmodule:: sky130.components
+
+.. autosummary::
+   :toctree: _autosummary/
+
+   sky130_fd_sc_hd__fa_1
+   sky130_fd_sc_hd__fa_2
+   sky130_fd_sc_hd__fa_4
+   sky130_fd_sc_hd__fah_1
+   sky130_fd_sc_hd__fahcin_1
+   sky130_fd_sc_hd__fahcon_1
+   sky130_fd_sc_hd__ha_1
+   sky130_fd_sc_hd__ha_2
+   sky130_fd_sc_hd__ha_4
+   sky130_fd_sc_hd__maj3_1
+   sky130_fd_sc_hd__maj3_2
+   sky130_fd_sc_hd__maj3_4
+
+Complex AOI / OAI gates
+^^^^^^^^^^^^^^^^^^^^^^^
+
+.. currentmodule:: sky130.components
+
+.. autosummary::
+   :toctree: _autosummary/
+
+   sky130_fd_sc_hd__a2111o_1
+   sky130_fd_sc_hd__a2111o_2
+   sky130_fd_sc_hd__a2111o_4
+   sky130_fd_sc_hd__a2111oi_0
+   sky130_fd_sc_hd__a2111oi_1
+   sky130_fd_sc_hd__a2111oi_2
+   sky130_fd_sc_hd__a2111oi_4
+   sky130_fd_sc_hd__a211o_1
+   sky130_fd_sc_hd__a211o_2
+   sky130_fd_sc_hd__a211o_4
+   sky130_fd_sc_hd__a211oi_1
+   sky130_fd_sc_hd__a211oi_2
+   sky130_fd_sc_hd__a211oi_4
+   sky130_fd_sc_hd__a21bo_1
+   sky130_fd_sc_hd__a21bo_2
+   sky130_fd_sc_hd__a21bo_4
+   sky130_fd_sc_hd__a21boi_0
+   sky130_fd_sc_hd__a21boi_1
+   sky130_fd_sc_hd__a21boi_2
+   sky130_fd_sc_hd__a21boi_4
+   sky130_fd_sc_hd__a21o_1
+   sky130_fd_sc_hd__a21o_2
+   sky130_fd_sc_hd__a21o_4
+   sky130_fd_sc_hd__a21oi_1
+   sky130_fd_sc_hd__a21oi_2
+   sky130_fd_sc_hd__a21oi_4
+   sky130_fd_sc_hd__a221o_1
+   sky130_fd_sc_hd__a221o_2
+   sky130_fd_sc_hd__a221o_4
+   sky130_fd_sc_hd__a221oi_1
+   sky130_fd_sc_hd__a221oi_2
+   sky130_fd_sc_hd__a221oi_4
+   sky130_fd_sc_hd__a222oi_1
+   sky130_fd_sc_hd__a22o_1
+   sky130_fd_sc_hd__a22o_2
+   sky130_fd_sc_hd__a22o_4
+   sky130_fd_sc_hd__a22oi_1
+   sky130_fd_sc_hd__a22oi_2
+   sky130_fd_sc_hd__a22oi_4
+   sky130_fd_sc_hd__a2bb2o_1
+   sky130_fd_sc_hd__a2bb2o_2
+   sky130_fd_sc_hd__a2bb2o_4
+   sky130_fd_sc_hd__a2bb2oi_1
+   sky130_fd_sc_hd__a2bb2oi_2
+   sky130_fd_sc_hd__a2bb2oi_4
+   sky130_fd_sc_hd__a311o_1
+   sky130_fd_sc_hd__a311o_2
+   sky130_fd_sc_hd__a311o_4
+   sky130_fd_sc_hd__a311oi_1
+   sky130_fd_sc_hd__a311oi_2
+   sky130_fd_sc_hd__a311oi_4
+   sky130_fd_sc_hd__a31o_1
+   sky130_fd_sc_hd__a31o_2
+   sky130_fd_sc_hd__a31o_4
+   sky130_fd_sc_hd__a31oi_1
+   sky130_fd_sc_hd__a31oi_2
+   sky130_fd_sc_hd__a31oi_4
+   sky130_fd_sc_hd__a32o_1
+   sky130_fd_sc_hd__a32o_2
+   sky130_fd_sc_hd__a32o_4
+   sky130_fd_sc_hd__a32oi_1
+   sky130_fd_sc_hd__a32oi_2
+   sky130_fd_sc_hd__a32oi_4
+   sky130_fd_sc_hd__a41o_1
+   sky130_fd_sc_hd__a41o_2
+   sky130_fd_sc_hd__a41o_4
+   sky130_fd_sc_hd__a41oi_1
+   sky130_fd_sc_hd__a41oi_2
+   sky130_fd_sc_hd__a41oi_4
+   sky130_fd_sc_hd__o2111a_1
+   sky130_fd_sc_hd__o2111a_2
+   sky130_fd_sc_hd__o2111a_4
+   sky130_fd_sc_hd__o2111ai_1
+   sky130_fd_sc_hd__o2111ai_2
+   sky130_fd_sc_hd__o2111ai_4
+   sky130_fd_sc_hd__o211a_1
+   sky130_fd_sc_hd__o211a_2
+   sky130_fd_sc_hd__o211a_4
+   sky130_fd_sc_hd__o211ai_1
+   sky130_fd_sc_hd__o211ai_2
+   sky130_fd_sc_hd__o211ai_4
+   sky130_fd_sc_hd__o21a_1
+   sky130_fd_sc_hd__o21a_2
+   sky130_fd_sc_hd__o21a_4
+   sky130_fd_sc_hd__o21ai_0
+   sky130_fd_sc_hd__o21ai_1
+   sky130_fd_sc_hd__o21ai_2
+   sky130_fd_sc_hd__o21ai_4
+   sky130_fd_sc_hd__o21ba_1
+   sky130_fd_sc_hd__o21ba_2
+   sky130_fd_sc_hd__o21ba_4
+   sky130_fd_sc_hd__o21bai_1
+   sky130_fd_sc_hd__o21bai_2
+   sky130_fd_sc_hd__o21bai_4
+   sky130_fd_sc_hd__o221a_1
+   sky130_fd_sc_hd__o221a_2
+   sky130_fd_sc_hd__o221a_4
+   sky130_fd_sc_hd__o221ai_1
+   sky130_fd_sc_hd__o221ai_2
+   sky130_fd_sc_hd__o221ai_4
+   sky130_fd_sc_hd__o22a_1
+   sky130_fd_sc_hd__o22a_2
+   sky130_fd_sc_hd__o22a_4
+   sky130_fd_sc_hd__o22ai_1
+   sky130_fd_sc_hd__o22ai_2
+   sky130_fd_sc_hd__o22ai_4
+   sky130_fd_sc_hd__o2bb2a_1
+   sky130_fd_sc_hd__o2bb2a_2
+   sky130_fd_sc_hd__o2bb2a_4
+   sky130_fd_sc_hd__o2bb2ai_1
+   sky130_fd_sc_hd__o2bb2ai_2
+   sky130_fd_sc_hd__o2bb2ai_4
+   sky130_fd_sc_hd__o311a_1
+   sky130_fd_sc_hd__o311a_2
+   sky130_fd_sc_hd__o311a_4
+   sky130_fd_sc_hd__o311ai_0
+   sky130_fd_sc_hd__o311ai_1
+   sky130_fd_sc_hd__o311ai_2
+   sky130_fd_sc_hd__o311ai_4
+   sky130_fd_sc_hd__o31a_1
+   sky130_fd_sc_hd__o31a_2
+   sky130_fd_sc_hd__o31a_4
+   sky130_fd_sc_hd__o31ai_1
+   sky130_fd_sc_hd__o31ai_2
+   sky130_fd_sc_hd__o31ai_4
+   sky130_fd_sc_hd__o32a_1
+   sky130_fd_sc_hd__o32a_2
+   sky130_fd_sc_hd__o32a_4
+   sky130_fd_sc_hd__o32ai_1
+   sky130_fd_sc_hd__o32ai_2
+   sky130_fd_sc_hd__o32ai_4
+   sky130_fd_sc_hd__o41a_1
+   sky130_fd_sc_hd__o41a_2
+   sky130_fd_sc_hd__o41a_4
+   sky130_fd_sc_hd__o41ai_1
+   sky130_fd_sc_hd__o41ai_2
+   sky130_fd_sc_hd__o41ai_4
+
+Flip-flops
+^^^^^^^^^^
+
+.. currentmodule:: sky130.components
+
+.. autosummary::
+   :toctree: _autosummary/
+
+   sky130_fd_sc_hd__dfbbn_1
+   sky130_fd_sc_hd__dfbbn_2
+   sky130_fd_sc_hd__dfbbp_1
+   sky130_fd_sc_hd__dfrbp_1
+   sky130_fd_sc_hd__dfrbp_2
+   sky130_fd_sc_hd__dfrtn_1
+   sky130_fd_sc_hd__dfrtp_1
+   sky130_fd_sc_hd__dfrtp_2
+   sky130_fd_sc_hd__dfrtp_4
+   sky130_fd_sc_hd__dfsbp_1
+   sky130_fd_sc_hd__dfsbp_2
+   sky130_fd_sc_hd__dfstp_1
+   sky130_fd_sc_hd__dfstp_2
+   sky130_fd_sc_hd__dfstp_4
+   sky130_fd_sc_hd__dfxbp_1
+   sky130_fd_sc_hd__dfxbp_2
+   sky130_fd_sc_hd__dfxtp_1
+   sky130_fd_sc_hd__dfxtp_2
+   sky130_fd_sc_hd__dfxtp_4
+   sky130_fd_sc_hd__edfxbp_1
+   sky130_fd_sc_hd__edfxtp_1
+   sky130_fd_sc_hd__sdfbbn_1
+   sky130_fd_sc_hd__sdfbbn_2
+   sky130_fd_sc_hd__sdfbbp_1
+   sky130_fd_sc_hd__sdfrbp_1
+   sky130_fd_sc_hd__sdfrbp_2
+   sky130_fd_sc_hd__sdfrtn_1
+   sky130_fd_sc_hd__sdfrtp_1
+   sky130_fd_sc_hd__sdfrtp_2
+   sky130_fd_sc_hd__sdfrtp_4
+   sky130_fd_sc_hd__sdfsbp_1
+   sky130_fd_sc_hd__sdfsbp_2
+   sky130_fd_sc_hd__sdfstp_1
+   sky130_fd_sc_hd__sdfstp_2
+   sky130_fd_sc_hd__sdfstp_4
+   sky130_fd_sc_hd__sdfxbp_1
+   sky130_fd_sc_hd__sdfxbp_2
+   sky130_fd_sc_hd__sdfxtp_1
+   sky130_fd_sc_hd__sdfxtp_2
+   sky130_fd_sc_hd__sdfxtp_4
+   sky130_fd_sc_hd__sedfxbp_1
+   sky130_fd_sc_hd__sedfxbp_2
+   sky130_fd_sc_hd__sedfxtp_1
+   sky130_fd_sc_hd__sedfxtp_2
+   sky130_fd_sc_hd__sedfxtp_4
+
+Latches & delay cells
+^^^^^^^^^^^^^^^^^^^^^
+
+.. currentmodule:: sky130.components
+
+.. autosummary::
+   :toctree: _autosummary/
+
+   sky130_fd_sc_hd__dlclkp_1
+   sky130_fd_sc_hd__dlclkp_2
+   sky130_fd_sc_hd__dlclkp_4
+   sky130_fd_sc_hd__dlrbn_1
+   sky130_fd_sc_hd__dlrbn_2
+   sky130_fd_sc_hd__dlrbp_1
+   sky130_fd_sc_hd__dlrbp_2
+   sky130_fd_sc_hd__dlrtn_1
+   sky130_fd_sc_hd__dlrtn_2
+   sky130_fd_sc_hd__dlrtn_4
+   sky130_fd_sc_hd__dlrtp_1
+   sky130_fd_sc_hd__dlrtp_2
+   sky130_fd_sc_hd__dlrtp_4
+   sky130_fd_sc_hd__dlxbn_1
+   sky130_fd_sc_hd__dlxbn_2
+   sky130_fd_sc_hd__dlxbp_1
+   sky130_fd_sc_hd__dlxtn_1
+   sky130_fd_sc_hd__dlxtn_2
+   sky130_fd_sc_hd__dlxtn_4
+   sky130_fd_sc_hd__dlxtp_1
+   sky130_fd_sc_hd__dlygate4sd1_1
+   sky130_fd_sc_hd__dlygate4sd2_1
+   sky130_fd_sc_hd__dlygate4sd3_1
+   sky130_fd_sc_hd__dlymetal6s2s_1
+   sky130_fd_sc_hd__dlymetal6s4s_1
+   sky130_fd_sc_hd__dlymetal6s6s_1
+   sky130_fd_sc_hd__sdlclkp_1
+   sky130_fd_sc_hd__sdlclkp_2
+   sky130_fd_sc_hd__sdlclkp_4
+
+Low-power
+^^^^^^^^^
+
+.. currentmodule:: sky130.components
+
+.. autosummary::
+   :toctree: _autosummary/
+
+   sky130_fd_sc_hd__lpflow_bleeder_1
+   sky130_fd_sc_hd__lpflow_clkbufkapwr_1
+   sky130_fd_sc_hd__lpflow_clkbufkapwr_16
+   sky130_fd_sc_hd__lpflow_clkbufkapwr_2
+   sky130_fd_sc_hd__lpflow_clkbufkapwr_4
+   sky130_fd_sc_hd__lpflow_clkbufkapwr_8
+   sky130_fd_sc_hd__lpflow_clkinvkapwr_1
+   sky130_fd_sc_hd__lpflow_clkinvkapwr_16
+   sky130_fd_sc_hd__lpflow_clkinvkapwr_2
+   sky130_fd_sc_hd__lpflow_clkinvkapwr_4
+   sky130_fd_sc_hd__lpflow_clkinvkapwr_8
+   sky130_fd_sc_hd__lpflow_decapkapwr_12
+   sky130_fd_sc_hd__lpflow_decapkapwr_3
+   sky130_fd_sc_hd__lpflow_decapkapwr_4
+   sky130_fd_sc_hd__lpflow_decapkapwr_6
+   sky130_fd_sc_hd__lpflow_decapkapwr_8
+   sky130_fd_sc_hd__lpflow_inputiso0n_1
+   sky130_fd_sc_hd__lpflow_inputiso0p_1
+   sky130_fd_sc_hd__lpflow_inputiso1n_1
+   sky130_fd_sc_hd__lpflow_inputiso1p_1
+   sky130_fd_sc_hd__lpflow_inputisolatch_1
+   sky130_fd_sc_hd__lpflow_isobufsrc_1
+   sky130_fd_sc_hd__lpflow_isobufsrc_16
+   sky130_fd_sc_hd__lpflow_isobufsrc_2
+   sky130_fd_sc_hd__lpflow_isobufsrc_4
+   sky130_fd_sc_hd__lpflow_isobufsrc_8
+   sky130_fd_sc_hd__lpflow_isobufsrckapwr_16
+   sky130_fd_sc_hd__lpflow_lsbuf_lh_hl_isowell_tap_1
+   sky130_fd_sc_hd__lpflow_lsbuf_lh_hl_isowell_tap_2
+   sky130_fd_sc_hd__lpflow_lsbuf_lh_hl_isowell_tap_4
+   sky130_fd_sc_hd__lpflow_lsbuf_lh_isowell_4
+   sky130_fd_sc_hd__lpflow_lsbuf_lh_isowell_tap_1
+   sky130_fd_sc_hd__lpflow_lsbuf_lh_isowell_tap_2
+   sky130_fd_sc_hd__lpflow_lsbuf_lh_isowell_tap_4
+
+Physical / fill / tap
+^^^^^^^^^^^^^^^^^^^^^
+
+.. currentmodule:: sky130.components
+
+.. autosummary::
+   :toctree: _autosummary/
+
+   sky130_fd_sc_hd__conb_1
+   sky130_fd_sc_hd__decap_12
+   sky130_fd_sc_hd__decap_3
+   sky130_fd_sc_hd__decap_4
+   sky130_fd_sc_hd__decap_6
+   sky130_fd_sc_hd__decap_8
+   sky130_fd_sc_hd__diode_2
+   sky130_fd_sc_hd__fill_1
+   sky130_fd_sc_hd__fill_2
+   sky130_fd_sc_hd__fill_4
+   sky130_fd_sc_hd__fill_8
+   sky130_fd_sc_hd__macro_sparecell
+   sky130_fd_sc_hd__probe_p_8
+   sky130_fd_sc_hd__probec_p_8
+   sky130_fd_sc_hd__tap_1
+   sky130_fd_sc_hd__tap_2
+   sky130_fd_sc_hd__tapvgnd2_1
+   sky130_fd_sc_hd__tapvgnd_1
+   sky130_fd_sc_hd__tapvpwrvgnd_1
+
+Analog / RF primitives (sky130_fd_pr)
+-------------------------------------
+
+Analog primitive devices: MOSFETs, BJTs, capacitors, ESD devices
+and RF test structures.
+
+Capacitors (MIM / VPP)
+^^^^^^^^^^^^^^^^^^^^^^
+
+.. currentmodule:: sky130.components
 
 .. autosummary::
    :toctree: _autosummary/
@@ -78,13 +648,15 @@ Cells
    sky130_fd_pr__cap_vpp_55p8x23p1_pol1m1m2m3m4m5_noshield
    sky130_fd_pr__cap_vpp_55p8x23p1_pol1m1m2m3m4m5_noshield_m5pullin
    sky130_fd_pr__cap_vpp_55p8x23p1_pol1m1m2m3m4m5_noshield_test
-   sky130_fd_pr__esd_rf_nfet_20v0_hbm_21vW60p00
-   sky130_fd_pr__esd_rf_nfet_20v0_hbm_32vW60p00
-   sky130_fd_pr__esd_rf_nfet_20v0_iec_21vW60p00
-   sky130_fd_pr__esd_rf_nfet_20v0_iec_32vW60p00
-   sky130_fd_pr__rf_aura_blocking
-   sky130_fd_pr__rf_aura_drc_flag_check
-   sky130_fd_pr__rf_aura_lvs_drc
+
+RF NFETs
+^^^^^^^^
+
+.. currentmodule:: sky130.components
+
+.. autosummary::
+   :toctree: _autosummary/
+
    sky130_fd_pr__rf_nfet_01v8_aM02W1p65L0p15
    sky130_fd_pr__rf_nfet_01v8_aM02W1p65L0p18
    sky130_fd_pr__rf_nfet_01v8_aM02W1p65L0p25
@@ -218,15 +790,15 @@ Cells
    sky130_fd_pr__rf_nfet_g5v0d10v5_bM10W3p00L0p50
    sky130_fd_pr__rf_nfet_g5v0d10v5_bM10W5p00L0p50
    sky130_fd_pr__rf_nfet_g5v0d10v5_bM10W7p00L0p50
-   sky130_fd_pr__rf_npn_05v5_W1p00L1p00
-   sky130_fd_pr__rf_npn_05v5_W1p00L2p00
-   sky130_fd_pr__rf_npn_05v5_W1p00L4p00
-   sky130_fd_pr__rf_npn_05v5_W1p00L8p00
-   sky130_fd_pr__rf_npn_05v5_W2p00L2p00
-   sky130_fd_pr__rf_npn_05v5_W2p00L4p00
-   sky130_fd_pr__rf_npn_05v5_W2p00L8p00
-   sky130_fd_pr__rf_npn_05v5_W5p00L5p00
-   sky130_fd_pr__rf_npn_11v0_W1p00L1p00
+
+RF PFETs
+^^^^^^^^
+
+.. currentmodule:: sky130.components
+
+.. autosummary::
+   :toctree: _autosummary/
+
    sky130_fd_pr__rf_pfet_01v8_aF02W0p84L0p15
    sky130_fd_pr__rf_pfet_01v8_aF02W1p68L0p15
    sky130_fd_pr__rf_pfet_01v8_aF02W2p00L0p15
@@ -293,445 +865,70 @@ Cells
    sky130_fd_pr__rf_pfet_01v8_mcM04W5p00L0p15
    sky130_fd_pr__rf_pfet_01v8_mvt_aF02W0p84L0p15
    sky130_fd_pr__rf_pfet_20v0_withptap
+
+RF NPN BJTs
+^^^^^^^^^^^
+
+.. currentmodule:: sky130.components
+
+.. autosummary::
+   :toctree: _autosummary/
+
+   sky130_fd_pr__rf_npn_05v5_W1p00L1p00
+   sky130_fd_pr__rf_npn_05v5_W1p00L2p00
+   sky130_fd_pr__rf_npn_05v5_W1p00L4p00
+   sky130_fd_pr__rf_npn_05v5_W1p00L8p00
+   sky130_fd_pr__rf_npn_05v5_W2p00L2p00
+   sky130_fd_pr__rf_npn_05v5_W2p00L4p00
+   sky130_fd_pr__rf_npn_05v5_W2p00L8p00
+   sky130_fd_pr__rf_npn_05v5_W5p00L5p00
+   sky130_fd_pr__rf_npn_11v0_W1p00L1p00
+
+RF PNP BJTs
+^^^^^^^^^^^
+
+.. currentmodule:: sky130.components
+
+.. autosummary::
+   :toctree: _autosummary/
+
    sky130_fd_pr__rf_pnp_05v5_W0p68L0p68
    sky130_fd_pr__rf_pnp_05v5_W3p40L3p40
+
+ESD devices
+^^^^^^^^^^^
+
+.. currentmodule:: sky130.components
+
+.. autosummary::
+   :toctree: _autosummary/
+
+   sky130_fd_pr__esd_rf_nfet_20v0_hbm_21vW60p00
+   sky130_fd_pr__esd_rf_nfet_20v0_hbm_32vW60p00
+   sky130_fd_pr__esd_rf_nfet_20v0_iec_21vW60p00
+   sky130_fd_pr__esd_rf_nfet_20v0_iec_32vW60p00
+
+RF test structures
+^^^^^^^^^^^^^^^^^^
+
+.. currentmodule:: sky130.components
+
+.. autosummary::
+   :toctree: _autosummary/
+
    sky130_fd_pr__rf_test_coil1
    sky130_fd_pr__rf_test_coil2
    sky130_fd_pr__rf_test_coil3
-   sky130_fd_sc_hd__a2111o_1
-   sky130_fd_sc_hd__a2111o_2
-   sky130_fd_sc_hd__a2111o_4
-   sky130_fd_sc_hd__a2111oi_0
-   sky130_fd_sc_hd__a2111oi_1
-   sky130_fd_sc_hd__a2111oi_2
-   sky130_fd_sc_hd__a2111oi_4
-   sky130_fd_sc_hd__a211o_1
-   sky130_fd_sc_hd__a211o_2
-   sky130_fd_sc_hd__a211o_4
-   sky130_fd_sc_hd__a211oi_1
-   sky130_fd_sc_hd__a211oi_2
-   sky130_fd_sc_hd__a211oi_4
-   sky130_fd_sc_hd__a21bo_1
-   sky130_fd_sc_hd__a21bo_2
-   sky130_fd_sc_hd__a21bo_4
-   sky130_fd_sc_hd__a21boi_0
-   sky130_fd_sc_hd__a21boi_1
-   sky130_fd_sc_hd__a21boi_2
-   sky130_fd_sc_hd__a21boi_4
-   sky130_fd_sc_hd__a21o_1
-   sky130_fd_sc_hd__a21o_2
-   sky130_fd_sc_hd__a21o_4
-   sky130_fd_sc_hd__a21oi_1
-   sky130_fd_sc_hd__a21oi_2
-   sky130_fd_sc_hd__a21oi_4
-   sky130_fd_sc_hd__a221o_1
-   sky130_fd_sc_hd__a221o_2
-   sky130_fd_sc_hd__a221o_4
-   sky130_fd_sc_hd__a221oi_1
-   sky130_fd_sc_hd__a221oi_2
-   sky130_fd_sc_hd__a221oi_4
-   sky130_fd_sc_hd__a222oi_1
-   sky130_fd_sc_hd__a22o_1
-   sky130_fd_sc_hd__a22o_2
-   sky130_fd_sc_hd__a22o_4
-   sky130_fd_sc_hd__a22oi_1
-   sky130_fd_sc_hd__a22oi_2
-   sky130_fd_sc_hd__a22oi_4
-   sky130_fd_sc_hd__a2bb2o_1
-   sky130_fd_sc_hd__a2bb2o_2
-   sky130_fd_sc_hd__a2bb2o_4
-   sky130_fd_sc_hd__a2bb2oi_1
-   sky130_fd_sc_hd__a2bb2oi_2
-   sky130_fd_sc_hd__a2bb2oi_4
-   sky130_fd_sc_hd__a311o_1
-   sky130_fd_sc_hd__a311o_2
-   sky130_fd_sc_hd__a311o_4
-   sky130_fd_sc_hd__a311oi_1
-   sky130_fd_sc_hd__a311oi_2
-   sky130_fd_sc_hd__a311oi_4
-   sky130_fd_sc_hd__a31o_1
-   sky130_fd_sc_hd__a31o_2
-   sky130_fd_sc_hd__a31o_4
-   sky130_fd_sc_hd__a31oi_1
-   sky130_fd_sc_hd__a31oi_2
-   sky130_fd_sc_hd__a31oi_4
-   sky130_fd_sc_hd__a32o_1
-   sky130_fd_sc_hd__a32o_2
-   sky130_fd_sc_hd__a32o_4
-   sky130_fd_sc_hd__a32oi_1
-   sky130_fd_sc_hd__a32oi_2
-   sky130_fd_sc_hd__a32oi_4
-   sky130_fd_sc_hd__a41o_1
-   sky130_fd_sc_hd__a41o_2
-   sky130_fd_sc_hd__a41o_4
-   sky130_fd_sc_hd__a41oi_1
-   sky130_fd_sc_hd__a41oi_2
-   sky130_fd_sc_hd__a41oi_4
-   sky130_fd_sc_hd__and2_0
-   sky130_fd_sc_hd__and2_1
-   sky130_fd_sc_hd__and2_2
-   sky130_fd_sc_hd__and2_4
-   sky130_fd_sc_hd__and2b_1
-   sky130_fd_sc_hd__and2b_2
-   sky130_fd_sc_hd__and2b_4
-   sky130_fd_sc_hd__and3_1
-   sky130_fd_sc_hd__and3_2
-   sky130_fd_sc_hd__and3_4
-   sky130_fd_sc_hd__and3b_1
-   sky130_fd_sc_hd__and3b_2
-   sky130_fd_sc_hd__and3b_4
-   sky130_fd_sc_hd__and4_1
-   sky130_fd_sc_hd__and4_2
-   sky130_fd_sc_hd__and4_4
-   sky130_fd_sc_hd__and4b_1
-   sky130_fd_sc_hd__and4b_2
-   sky130_fd_sc_hd__and4b_4
-   sky130_fd_sc_hd__and4bb_1
-   sky130_fd_sc_hd__and4bb_2
-   sky130_fd_sc_hd__and4bb_4
-   sky130_fd_sc_hd__buf_1
-   sky130_fd_sc_hd__buf_12
-   sky130_fd_sc_hd__buf_16
-   sky130_fd_sc_hd__buf_2
-   sky130_fd_sc_hd__buf_4
-   sky130_fd_sc_hd__buf_6
-   sky130_fd_sc_hd__buf_8
-   sky130_fd_sc_hd__bufbuf_16
-   sky130_fd_sc_hd__bufbuf_8
-   sky130_fd_sc_hd__bufinv_16
-   sky130_fd_sc_hd__bufinv_8
-   sky130_fd_sc_hd__clkbuf_1
-   sky130_fd_sc_hd__clkbuf_16
-   sky130_fd_sc_hd__clkbuf_2
-   sky130_fd_sc_hd__clkbuf_4
-   sky130_fd_sc_hd__clkbuf_8
-   sky130_fd_sc_hd__clkdlybuf4s15_1
-   sky130_fd_sc_hd__clkdlybuf4s15_2
-   sky130_fd_sc_hd__clkdlybuf4s18_1
-   sky130_fd_sc_hd__clkdlybuf4s18_2
-   sky130_fd_sc_hd__clkdlybuf4s25_1
-   sky130_fd_sc_hd__clkdlybuf4s25_2
-   sky130_fd_sc_hd__clkdlybuf4s50_1
-   sky130_fd_sc_hd__clkdlybuf4s50_2
-   sky130_fd_sc_hd__clkinv_1
-   sky130_fd_sc_hd__clkinv_16
-   sky130_fd_sc_hd__clkinv_2
-   sky130_fd_sc_hd__clkinv_4
-   sky130_fd_sc_hd__clkinv_8
-   sky130_fd_sc_hd__clkinvlp_2
-   sky130_fd_sc_hd__clkinvlp_4
-   sky130_fd_sc_hd__conb_1
-   sky130_fd_sc_hd__decap_12
-   sky130_fd_sc_hd__decap_3
-   sky130_fd_sc_hd__decap_4
-   sky130_fd_sc_hd__decap_6
-   sky130_fd_sc_hd__decap_8
-   sky130_fd_sc_hd__dfbbn_1
-   sky130_fd_sc_hd__dfbbn_2
-   sky130_fd_sc_hd__dfbbp_1
-   sky130_fd_sc_hd__dfrbp_1
-   sky130_fd_sc_hd__dfrbp_2
-   sky130_fd_sc_hd__dfrtn_1
-   sky130_fd_sc_hd__dfrtp_1
-   sky130_fd_sc_hd__dfrtp_2
-   sky130_fd_sc_hd__dfrtp_4
-   sky130_fd_sc_hd__dfsbp_1
-   sky130_fd_sc_hd__dfsbp_2
-   sky130_fd_sc_hd__dfstp_1
-   sky130_fd_sc_hd__dfstp_2
-   sky130_fd_sc_hd__dfstp_4
-   sky130_fd_sc_hd__dfxbp_1
-   sky130_fd_sc_hd__dfxbp_2
-   sky130_fd_sc_hd__dfxtp_1
-   sky130_fd_sc_hd__dfxtp_2
-   sky130_fd_sc_hd__dfxtp_4
-   sky130_fd_sc_hd__diode_2
-   sky130_fd_sc_hd__dlclkp_1
-   sky130_fd_sc_hd__dlclkp_2
-   sky130_fd_sc_hd__dlclkp_4
-   sky130_fd_sc_hd__dlrbn_1
-   sky130_fd_sc_hd__dlrbn_2
-   sky130_fd_sc_hd__dlrbp_1
-   sky130_fd_sc_hd__dlrbp_2
-   sky130_fd_sc_hd__dlrtn_1
-   sky130_fd_sc_hd__dlrtn_2
-   sky130_fd_sc_hd__dlrtn_4
-   sky130_fd_sc_hd__dlrtp_1
-   sky130_fd_sc_hd__dlrtp_2
-   sky130_fd_sc_hd__dlrtp_4
-   sky130_fd_sc_hd__dlxbn_1
-   sky130_fd_sc_hd__dlxbn_2
-   sky130_fd_sc_hd__dlxbp_1
-   sky130_fd_sc_hd__dlxtn_1
-   sky130_fd_sc_hd__dlxtn_2
-   sky130_fd_sc_hd__dlxtn_4
-   sky130_fd_sc_hd__dlxtp_1
-   sky130_fd_sc_hd__dlygate4sd1_1
-   sky130_fd_sc_hd__dlygate4sd2_1
-   sky130_fd_sc_hd__dlygate4sd3_1
-   sky130_fd_sc_hd__dlymetal6s2s_1
-   sky130_fd_sc_hd__dlymetal6s4s_1
-   sky130_fd_sc_hd__dlymetal6s6s_1
-   sky130_fd_sc_hd__ebufn_1
-   sky130_fd_sc_hd__ebufn_2
-   sky130_fd_sc_hd__ebufn_4
-   sky130_fd_sc_hd__ebufn_8
-   sky130_fd_sc_hd__edfxbp_1
-   sky130_fd_sc_hd__edfxtp_1
-   sky130_fd_sc_hd__einvn_0
-   sky130_fd_sc_hd__einvn_1
-   sky130_fd_sc_hd__einvn_2
-   sky130_fd_sc_hd__einvn_4
-   sky130_fd_sc_hd__einvn_8
-   sky130_fd_sc_hd__einvp_1
-   sky130_fd_sc_hd__einvp_2
-   sky130_fd_sc_hd__einvp_4
-   sky130_fd_sc_hd__einvp_8
-   sky130_fd_sc_hd__fa_1
-   sky130_fd_sc_hd__fa_2
-   sky130_fd_sc_hd__fa_4
-   sky130_fd_sc_hd__fah_1
-   sky130_fd_sc_hd__fahcin_1
-   sky130_fd_sc_hd__fahcon_1
-   sky130_fd_sc_hd__fill_1
-   sky130_fd_sc_hd__fill_2
-   sky130_fd_sc_hd__fill_4
-   sky130_fd_sc_hd__fill_8
-   sky130_fd_sc_hd__ha_1
-   sky130_fd_sc_hd__ha_2
-   sky130_fd_sc_hd__ha_4
-   sky130_fd_sc_hd__inv_1
-   sky130_fd_sc_hd__inv_12
-   sky130_fd_sc_hd__inv_16
-   sky130_fd_sc_hd__inv_2
-   sky130_fd_sc_hd__inv_4
-   sky130_fd_sc_hd__inv_6
-   sky130_fd_sc_hd__inv_8
-   sky130_fd_sc_hd__lpflow_bleeder_1
-   sky130_fd_sc_hd__lpflow_clkbufkapwr_1
-   sky130_fd_sc_hd__lpflow_clkbufkapwr_16
-   sky130_fd_sc_hd__lpflow_clkbufkapwr_2
-   sky130_fd_sc_hd__lpflow_clkbufkapwr_4
-   sky130_fd_sc_hd__lpflow_clkbufkapwr_8
-   sky130_fd_sc_hd__lpflow_clkinvkapwr_1
-   sky130_fd_sc_hd__lpflow_clkinvkapwr_16
-   sky130_fd_sc_hd__lpflow_clkinvkapwr_2
-   sky130_fd_sc_hd__lpflow_clkinvkapwr_4
-   sky130_fd_sc_hd__lpflow_clkinvkapwr_8
-   sky130_fd_sc_hd__lpflow_decapkapwr_12
-   sky130_fd_sc_hd__lpflow_decapkapwr_3
-   sky130_fd_sc_hd__lpflow_decapkapwr_4
-   sky130_fd_sc_hd__lpflow_decapkapwr_6
-   sky130_fd_sc_hd__lpflow_decapkapwr_8
-   sky130_fd_sc_hd__lpflow_inputiso0n_1
-   sky130_fd_sc_hd__lpflow_inputiso0p_1
-   sky130_fd_sc_hd__lpflow_inputiso1n_1
-   sky130_fd_sc_hd__lpflow_inputiso1p_1
-   sky130_fd_sc_hd__lpflow_inputisolatch_1
-   sky130_fd_sc_hd__lpflow_isobufsrc_1
-   sky130_fd_sc_hd__lpflow_isobufsrc_16
-   sky130_fd_sc_hd__lpflow_isobufsrc_2
-   sky130_fd_sc_hd__lpflow_isobufsrc_4
-   sky130_fd_sc_hd__lpflow_isobufsrc_8
-   sky130_fd_sc_hd__lpflow_isobufsrckapwr_16
-   sky130_fd_sc_hd__lpflow_lsbuf_lh_hl_isowell_tap_1
-   sky130_fd_sc_hd__lpflow_lsbuf_lh_hl_isowell_tap_2
-   sky130_fd_sc_hd__lpflow_lsbuf_lh_hl_isowell_tap_4
-   sky130_fd_sc_hd__lpflow_lsbuf_lh_isowell_4
-   sky130_fd_sc_hd__lpflow_lsbuf_lh_isowell_tap_1
-   sky130_fd_sc_hd__lpflow_lsbuf_lh_isowell_tap_2
-   sky130_fd_sc_hd__lpflow_lsbuf_lh_isowell_tap_4
-   sky130_fd_sc_hd__macro_sparecell
-   sky130_fd_sc_hd__maj3_1
-   sky130_fd_sc_hd__maj3_2
-   sky130_fd_sc_hd__maj3_4
-   sky130_fd_sc_hd__mux2_1
-   sky130_fd_sc_hd__mux2_2
-   sky130_fd_sc_hd__mux2_4
-   sky130_fd_sc_hd__mux2_8
-   sky130_fd_sc_hd__mux2i_1
-   sky130_fd_sc_hd__mux2i_2
-   sky130_fd_sc_hd__mux2i_4
-   sky130_fd_sc_hd__mux4_1
-   sky130_fd_sc_hd__mux4_2
-   sky130_fd_sc_hd__mux4_4
-   sky130_fd_sc_hd__nand2_1
-   sky130_fd_sc_hd__nand2_2
-   sky130_fd_sc_hd__nand2_4
-   sky130_fd_sc_hd__nand2_8
-   sky130_fd_sc_hd__nand2b_1
-   sky130_fd_sc_hd__nand2b_2
-   sky130_fd_sc_hd__nand2b_4
-   sky130_fd_sc_hd__nand3_1
-   sky130_fd_sc_hd__nand3_2
-   sky130_fd_sc_hd__nand3_4
-   sky130_fd_sc_hd__nand3b_1
-   sky130_fd_sc_hd__nand3b_2
-   sky130_fd_sc_hd__nand3b_4
-   sky130_fd_sc_hd__nand4_1
-   sky130_fd_sc_hd__nand4_2
-   sky130_fd_sc_hd__nand4_4
-   sky130_fd_sc_hd__nand4b_1
-   sky130_fd_sc_hd__nand4b_2
-   sky130_fd_sc_hd__nand4b_4
-   sky130_fd_sc_hd__nand4bb_1
-   sky130_fd_sc_hd__nand4bb_2
-   sky130_fd_sc_hd__nand4bb_4
-   sky130_fd_sc_hd__nor2_1
-   sky130_fd_sc_hd__nor2_2
-   sky130_fd_sc_hd__nor2_4
-   sky130_fd_sc_hd__nor2_8
-   sky130_fd_sc_hd__nor2b_1
-   sky130_fd_sc_hd__nor2b_2
-   sky130_fd_sc_hd__nor2b_4
-   sky130_fd_sc_hd__nor3_1
-   sky130_fd_sc_hd__nor3_2
-   sky130_fd_sc_hd__nor3_4
-   sky130_fd_sc_hd__nor3b_1
-   sky130_fd_sc_hd__nor3b_2
-   sky130_fd_sc_hd__nor3b_4
-   sky130_fd_sc_hd__nor4_1
-   sky130_fd_sc_hd__nor4_2
-   sky130_fd_sc_hd__nor4_4
-   sky130_fd_sc_hd__nor4b_1
-   sky130_fd_sc_hd__nor4b_2
-   sky130_fd_sc_hd__nor4b_4
-   sky130_fd_sc_hd__nor4bb_1
-   sky130_fd_sc_hd__nor4bb_2
-   sky130_fd_sc_hd__nor4bb_4
-   sky130_fd_sc_hd__o2111a_1
-   sky130_fd_sc_hd__o2111a_2
-   sky130_fd_sc_hd__o2111a_4
-   sky130_fd_sc_hd__o2111ai_1
-   sky130_fd_sc_hd__o2111ai_2
-   sky130_fd_sc_hd__o2111ai_4
-   sky130_fd_sc_hd__o211a_1
-   sky130_fd_sc_hd__o211a_2
-   sky130_fd_sc_hd__o211a_4
-   sky130_fd_sc_hd__o211ai_1
-   sky130_fd_sc_hd__o211ai_2
-   sky130_fd_sc_hd__o211ai_4
-   sky130_fd_sc_hd__o21a_1
-   sky130_fd_sc_hd__o21a_2
-   sky130_fd_sc_hd__o21a_4
-   sky130_fd_sc_hd__o21ai_0
-   sky130_fd_sc_hd__o21ai_1
-   sky130_fd_sc_hd__o21ai_2
-   sky130_fd_sc_hd__o21ai_4
-   sky130_fd_sc_hd__o21ba_1
-   sky130_fd_sc_hd__o21ba_2
-   sky130_fd_sc_hd__o21ba_4
-   sky130_fd_sc_hd__o21bai_1
-   sky130_fd_sc_hd__o21bai_2
-   sky130_fd_sc_hd__o21bai_4
-   sky130_fd_sc_hd__o221a_1
-   sky130_fd_sc_hd__o221a_2
-   sky130_fd_sc_hd__o221a_4
-   sky130_fd_sc_hd__o221ai_1
-   sky130_fd_sc_hd__o221ai_2
-   sky130_fd_sc_hd__o221ai_4
-   sky130_fd_sc_hd__o22a_1
-   sky130_fd_sc_hd__o22a_2
-   sky130_fd_sc_hd__o22a_4
-   sky130_fd_sc_hd__o22ai_1
-   sky130_fd_sc_hd__o22ai_2
-   sky130_fd_sc_hd__o22ai_4
-   sky130_fd_sc_hd__o2bb2a_1
-   sky130_fd_sc_hd__o2bb2a_2
-   sky130_fd_sc_hd__o2bb2a_4
-   sky130_fd_sc_hd__o2bb2ai_1
-   sky130_fd_sc_hd__o2bb2ai_2
-   sky130_fd_sc_hd__o2bb2ai_4
-   sky130_fd_sc_hd__o311a_1
-   sky130_fd_sc_hd__o311a_2
-   sky130_fd_sc_hd__o311a_4
-   sky130_fd_sc_hd__o311ai_0
-   sky130_fd_sc_hd__o311ai_1
-   sky130_fd_sc_hd__o311ai_2
-   sky130_fd_sc_hd__o311ai_4
-   sky130_fd_sc_hd__o31a_1
-   sky130_fd_sc_hd__o31a_2
-   sky130_fd_sc_hd__o31a_4
-   sky130_fd_sc_hd__o31ai_1
-   sky130_fd_sc_hd__o31ai_2
-   sky130_fd_sc_hd__o31ai_4
-   sky130_fd_sc_hd__o32a_1
-   sky130_fd_sc_hd__o32a_2
-   sky130_fd_sc_hd__o32a_4
-   sky130_fd_sc_hd__o32ai_1
-   sky130_fd_sc_hd__o32ai_2
-   sky130_fd_sc_hd__o32ai_4
-   sky130_fd_sc_hd__o41a_1
-   sky130_fd_sc_hd__o41a_2
-   sky130_fd_sc_hd__o41a_4
-   sky130_fd_sc_hd__o41ai_1
-   sky130_fd_sc_hd__o41ai_2
-   sky130_fd_sc_hd__o41ai_4
-   sky130_fd_sc_hd__or2_0
-   sky130_fd_sc_hd__or2_1
-   sky130_fd_sc_hd__or2_2
-   sky130_fd_sc_hd__or2_4
-   sky130_fd_sc_hd__or2b_1
-   sky130_fd_sc_hd__or2b_2
-   sky130_fd_sc_hd__or2b_4
-   sky130_fd_sc_hd__or3_1
-   sky130_fd_sc_hd__or3_2
-   sky130_fd_sc_hd__or3_4
-   sky130_fd_sc_hd__or3b_1
-   sky130_fd_sc_hd__or3b_2
-   sky130_fd_sc_hd__or3b_4
-   sky130_fd_sc_hd__or4_1
-   sky130_fd_sc_hd__or4_2
-   sky130_fd_sc_hd__or4_4
-   sky130_fd_sc_hd__or4b_1
-   sky130_fd_sc_hd__or4b_2
-   sky130_fd_sc_hd__or4b_4
-   sky130_fd_sc_hd__or4bb_1
-   sky130_fd_sc_hd__or4bb_2
-   sky130_fd_sc_hd__or4bb_4
-   sky130_fd_sc_hd__probe_p_8
-   sky130_fd_sc_hd__probec_p_8
-   sky130_fd_sc_hd__sdfbbn_1
-   sky130_fd_sc_hd__sdfbbn_2
-   sky130_fd_sc_hd__sdfbbp_1
-   sky130_fd_sc_hd__sdfrbp_1
-   sky130_fd_sc_hd__sdfrbp_2
-   sky130_fd_sc_hd__sdfrtn_1
-   sky130_fd_sc_hd__sdfrtp_1
-   sky130_fd_sc_hd__sdfrtp_2
-   sky130_fd_sc_hd__sdfrtp_4
-   sky130_fd_sc_hd__sdfsbp_1
-   sky130_fd_sc_hd__sdfsbp_2
-   sky130_fd_sc_hd__sdfstp_1
-   sky130_fd_sc_hd__sdfstp_2
-   sky130_fd_sc_hd__sdfstp_4
-   sky130_fd_sc_hd__sdfxbp_1
-   sky130_fd_sc_hd__sdfxbp_2
-   sky130_fd_sc_hd__sdfxtp_1
-   sky130_fd_sc_hd__sdfxtp_2
-   sky130_fd_sc_hd__sdfxtp_4
-   sky130_fd_sc_hd__sdlclkp_1
-   sky130_fd_sc_hd__sdlclkp_2
-   sky130_fd_sc_hd__sdlclkp_4
-   sky130_fd_sc_hd__sedfxbp_1
-   sky130_fd_sc_hd__sedfxbp_2
-   sky130_fd_sc_hd__sedfxtp_1
-   sky130_fd_sc_hd__sedfxtp_2
-   sky130_fd_sc_hd__sedfxtp_4
-   sky130_fd_sc_hd__tap_1
-   sky130_fd_sc_hd__tap_2
-   sky130_fd_sc_hd__tapvgnd2_1
-   sky130_fd_sc_hd__tapvgnd_1
-   sky130_fd_sc_hd__tapvpwrvgnd_1
-   sky130_fd_sc_hd__xnor2_1
-   sky130_fd_sc_hd__xnor2_2
-   sky130_fd_sc_hd__xnor2_4
-   sky130_fd_sc_hd__xnor3_1
-   sky130_fd_sc_hd__xnor3_2
-   sky130_fd_sc_hd__xnor3_4
-   sky130_fd_sc_hd__xor2_1
-   sky130_fd_sc_hd__xor2_2
-   sky130_fd_sc_hd__xor2_4
-   sky130_fd_sc_hd__xor3_1
-   sky130_fd_sc_hd__xor3_2
-   sky130_fd_sc_hd__xor3_4
+
+RF aura test structures
+^^^^^^^^^^^^^^^^^^^^^^^
+
+.. currentmodule:: sky130.components
+
+.. autosummary::
+   :toctree: _autosummary/
+
+   sky130_fd_pr__rf_aura_blocking
+   sky130_fd_pr__rf_aura_drc_flag_check
+   sky130_fd_pr__rf_aura_lvs_drc
+

--- a/docs/components.rst
+++ b/docs/components.rst
@@ -931,4 +931,3 @@ RF aura test structures
    sky130_fd_pr__rf_aura_blocking
    sky130_fd_pr__rf_aura_drc_flag_check
    sky130_fd_pr__rf_aura_lvs_drc
-

--- a/docs/pcells.rst
+++ b/docs/pcells.rst
@@ -68,4 +68,3 @@ Routing primitives
    waypoint
    wire_corner
    wire_corner45
-

--- a/docs/pcells.rst
+++ b/docs/pcells.rst
@@ -1,9 +1,58 @@
-
-
-Here are the Parametric Pcells available in the PDK
-
 PCells
-=============================
+======
+
+Parametric cells available in the PDK, grouped by device family.
+
+MOSFETs
+-------
+
+.. currentmodule:: sky130.pcells
+
+.. autosummary::
+   :toctree: _autosummary/
+
+   nmos
+   nmos_5v
+   pmos
+   pmos_5v
+
+Bipolar transistors
+-------------------
+
+.. currentmodule:: sky130.pcells
+
+.. autosummary::
+   :toctree: _autosummary/
+
+   npn_W1L1
+   npn_W1L2
+   pnp
+
+Capacitors & poly resistors
+---------------------------
+
+.. currentmodule:: sky130.pcells
+
+.. autosummary::
+   :toctree: _autosummary/
+
+   mimcap_1
+   mimcap_2
+   p_n_poly
+   p_p_poly
+
+Vias
+----
+
+.. currentmodule:: sky130.pcells
+
+.. autosummary::
+   :toctree: _autosummary/
+
+   via_generator
+
+Routing primitives
+------------------
 
 .. currentmodule:: sky130.pcells
 
@@ -14,20 +63,9 @@ PCells
    bend_metal2
    bend_s_metal1
    bend_s_metal2
-   mimcap_1
-   mimcap_2
-   nmos
-   nmos_5v
-   npn_W1L1
-   npn_W1L2
-   p_n_poly
-   p_p_poly
-   pmos
-   pmos_5v
-   pnp
    straight_metal1
    straight_metal2
-   via_generator
    waypoint
    wire_corner
    wire_corner45
+

--- a/docs/write_components_doc.py
+++ b/docs/write_components_doc.py
@@ -1,12 +1,30 @@
-import inspect
+"""Generate sectioned ``components.rst`` and ``pcells.rst`` for the docs.
+
+Cells are grouped by function so that the docs are easier to navigate than a
+single flat list:
+
+* ``components.rst`` splits the fixed (GDS-backed) cells into the digital
+  standard-cell library (``sky130_fd_sc_hd``) and the analog primitive
+  library (``sky130_fd_pr``).  Each library is further split into
+  sub-sections (e.g. inverters/buffers, flip-flops, MOSFETs, capacitors,
+  ESD, ...).
+* ``pcells.rst`` splits the parametric cells into analog devices, vias and
+  routing primitives.
+"""
+
+from __future__ import annotations
+
 import pathlib
+import re
+from collections.abc import Iterable
 
 import sky130
 
-cells = pathlib.Path(__file__).parent.absolute() / "components.rst"
-pcells = pathlib.Path(__file__).parent.absolute() / "pcells.rst"
+HERE = pathlib.Path(__file__).parent.absolute()
+COMPONENTS_RST = HERE / "components.rst"
+PCELLS_RST = HERE / "pcells.rst"
 
-skip = {
+SKIP = {
     "LIBRARY",
     "circuit_names",
     "cells",
@@ -24,71 +42,257 @@ skip = {
     "import_gds",
 }
 
-skip_plot = {}
-skip_settings = {"flatten", "safe_cell_names"}
 
-pcell_names = set(sky130.pcells.__all__)
-cell_names = set(sky130.cells.keys()) - pcell_names
+# ---------------------------------------------------------------------------
+# Categorisation
+# ---------------------------------------------------------------------------
+
+SC_PREFIX = "sky130_fd_sc_hd__"
+PR_PREFIX = "sky130_fd_pr__"
 
 
-with open(pcells, "w+") as f:
-    f.write(
-        """
+def _sc_category(name: str) -> str:
+    """Bucket a ``sky130_fd_sc_hd__*`` standard cell by function."""
+    base = name[len(SC_PREFIX) :]
+    base = re.sub(r"_\d+$", "", base)  # drop drive-strength suffix
 
-Here are the Parametric Pcells available in the PDK
+    if base in {
+        "decap",
+        "diode",
+        "fill",
+        "fillcap",
+        "tap",
+        "tapvgnd",
+        "tapvgnd2",
+        "tapvpwrvgnd",
+        "conb",
+        "macro_sparecell",
+        "probe_p",
+        "probec_p",
+    } or base.startswith(("fill", "tap", "decap", "probe")):
+        return "Physical / fill / tap"
 
-PCells
-=============================
+    if base.startswith(("clkbuf", "clkinv", "clkdly", "clkdlybuf", "clk")):
+        return "Clock"
+    if base.startswith(("buf", "bufinv", "bufbuf", "ebuf")):
+        return "Buffers"
+    if base.startswith(("inv", "einv")):
+        return "Inverters"
+    if base.startswith("mux"):
+        return "Multiplexers"
+    if base.startswith(("xnor", "xor")):
+        return "XOR / XNOR"
+    if base.startswith(("nand", "and")):
+        return "AND / NAND"
+    if base.startswith(("nor", "or")):
+        return "OR / NOR"
+    if base.startswith(("ha", "fa", "maj")):
+        return "Arithmetic (adders / majority)"
+    if base.startswith(("a2", "a3", "a4", "o2", "o3", "o4")):
+        return "Complex AOI / OAI gates"
+    if base.startswith(("df", "sdf", "sed", "edf")):
+        return "Flip-flops"
+    if base.startswith(("dl", "sdl")):
+        return "Latches & delay cells"
+    if base.startswith(("lpflow", "sleep", "iso")):
+        return "Low-power"
+    return "Other"
 
-.. currentmodule:: sky130.pcells
 
-.. autosummary::
-   :toctree: _autosummary/
+def _pr_category(name: str) -> str:
+    """Bucket a ``sky130_fd_pr__*`` analog primitive cell by function."""
+    base = name[len(PR_PREFIX) :]
 
-"""
+    if base.startswith("cap_"):
+        return "Capacitors (MIM / VPP)"
+    if base.startswith("esd_"):
+        return "ESD devices"
+    if base.startswith("rf_nfet"):
+        return "RF NFETs"
+    if base.startswith("rf_pfet"):
+        return "RF PFETs"
+    if base.startswith("rf_npn"):
+        return "RF NPN BJTs"
+    if base.startswith("rf_pnp"):
+        return "RF PNP BJTs"
+    if base.startswith("rf_test"):
+        return "RF test structures"
+    if base.startswith("rf_aura"):
+        return "RF aura test structures"
+    if base.startswith("rf_"):
+        return "RF other"
+    return "Analog other"
+
+
+def _pcell_category(name: str) -> str:
+    """Bucket a parametric cell by function."""
+    if name in {"nmos", "nmos_5v", "pmos", "pmos_5v"}:
+        return "MOSFETs"
+    if name in {"npn_W1L1", "npn_W1L2", "pnp"}:
+        return "Bipolar transistors"
+    if name in {"mimcap_1", "mimcap_2", "p_n_poly", "p_p_poly"}:
+        return "Capacitors & poly resistors"
+    if name in {"via_generator"} or name.startswith("via"):
+        return "Vias"
+    if (
+        name.startswith(("bend_", "straight_", "wire_"))
+        or name == "waypoint"
+    ):
+        return "Routing primitives"
+    return "Other"
+
+
+# Order in which categories are rendered.
+SC_ORDER: list[str] = [
+    "Inverters",
+    "Buffers",
+    "Clock",
+    "AND / NAND",
+    "OR / NOR",
+    "XOR / XNOR",
+    "Multiplexers",
+    "Arithmetic (adders / majority)",
+    "Complex AOI / OAI gates",
+    "Flip-flops",
+    "Latches & delay cells",
+    "Low-power",
+    "Physical / fill / tap",
+    "Other",
+]
+
+PR_ORDER: list[str] = [
+    "Capacitors (MIM / VPP)",
+    "RF NFETs",
+    "RF PFETs",
+    "RF NPN BJTs",
+    "RF PNP BJTs",
+    "ESD devices",
+    "RF test structures",
+    "RF aura test structures",
+    "RF other",
+    "Analog other",
+]
+
+PCELL_ORDER: list[str] = [
+    "MOSFETs",
+    "Bipolar transistors",
+    "Capacitors & poly resistors",
+    "Vias",
+    "Routing primitives",
+    "Other",
+]
+
+
+# ---------------------------------------------------------------------------
+# Rendering
+# ---------------------------------------------------------------------------
+
+
+def _heading(text: str, char: str) -> str:
+    return f"{text}\n{char * len(text)}\n"
+
+
+def _autosummary(module: str, names: Iterable[str]) -> str:
+    body = [
+        f".. currentmodule:: {module}",
+        "",
+        ".. autosummary::",
+        "   :toctree: _autosummary/",
+        "",
+    ]
+    body += [f"   {n}" for n in names]
+    body.append("")
+    return "\n".join(body)
+
+
+def _grouped(names: Iterable[str], categorize, order: list[str]) -> dict[str, list[str]]:
+    groups: dict[str, list[str]] = {k: [] for k in order}
+    for n in sorted(names):
+        if n in SKIP or n.startswith("_"):
+            continue
+        cat = categorize(n)
+        groups.setdefault(cat, []).append(n)
+    return {k: v for k, v in groups.items() if v}
+
+
+def write_components() -> None:
+    all_names = set(sky130.cells.keys())
+    pcell_names = set(sky130.pcells.__all__)
+    fixed_names = all_names - pcell_names
+
+    sc_names = [n for n in fixed_names if n.startswith(SC_PREFIX)]
+    pr_names = [n for n in fixed_names if n.startswith(PR_PREFIX)]
+
+    sc_groups = _grouped(sc_names, _sc_category, SC_ORDER)
+    pr_groups = _grouped(pr_names, _pr_category, PR_ORDER)
+
+    out: list[str] = []
+    out.append(_heading("Cells", "="))
+    out.append(
+        "Fixed (GDS-backed) cells available in the PDK, grouped by function.\n"
     )
 
-    for name in sorted(pcell_names):
-        if name in skip or name.startswith("_"):
-            continue
-        print(name)
-        sig = inspect.signature(sky130.PDK.cells[name])
-        kwargs = ", ".join(
-            [
-                f"{p}={repr(sig.parameters[p].default)}"
-                for p in sig.parameters
-                if isinstance(sig.parameters[p].default, int | float | str | tuple)
-                and p not in skip_settings
-            ]
-        )
-        f.write(f"   {name}\n")
-
-with open(cells, "w+") as f:
-    f.write(
-        """
-
-Cells
-=============================
-
-.. currentmodule:: sky130.components
-
-.. autosummary::
-   :toctree: _autosummary/
-
-"""
+    out.append(_heading("Digital standard cells (sky130_fd_sc_hd)", "-"))
+    out.append(
+        "High-density digital standard-cell library.  Cells are grouped by\n"
+        "logical function.  The trailing ``_N`` in each name encodes the\n"
+        "drive strength.\n"
     )
-
-    for name in sorted(cell_names):
-        if name in skip or name.startswith("_"):
+    for cat in SC_ORDER:
+        names = sc_groups.get(cat)
+        if not names:
             continue
-        print(name)
-        sig = inspect.signature(sky130.cells[name])
-        kwargs = ", ".join(
-            [
-                f"{p}={repr(sig.parameters[p].default)}"
-                for p in sig.parameters
-                if isinstance(sig.parameters[p].default, int | float | str | tuple)
-                and p not in skip_settings
-            ]
-        )
-        f.write(f"   {name}\n")
+        out.append(_heading(cat, "^"))
+        out.append(_autosummary("sky130.components", names))
+
+    out.append(_heading("Analog / RF primitives (sky130_fd_pr)", "-"))
+    out.append(
+        "Analog primitive devices: MOSFETs, BJTs, capacitors, ESD devices\n"
+        "and RF test structures.\n"
+    )
+    for cat in PR_ORDER:
+        names = pr_groups.get(cat)
+        if not names:
+            continue
+        out.append(_heading(cat, "^"))
+        out.append(_autosummary("sky130.components", names))
+
+    # Anything that didn't match either prefix
+    leftover = sorted(
+        n
+        for n in fixed_names
+        if not n.startswith((SC_PREFIX, PR_PREFIX))
+        and n not in SKIP
+        and not n.startswith("_")
+    )
+    if leftover:
+        out.append(_heading("Other fixed cells", "-"))
+        out.append(_autosummary("sky130.components", leftover))
+
+    COMPONENTS_RST.write_text("\n".join(out) + "\n")
+
+
+def write_pcells() -> None:
+    pcell_names = list(sky130.pcells.__all__)
+    groups = _grouped(pcell_names, _pcell_category, PCELL_ORDER)
+
+    out: list[str] = []
+    out.append(_heading("PCells", "="))
+    out.append(
+        "Parametric cells available in the PDK, grouped by device family.\n"
+    )
+    for cat in PCELL_ORDER:
+        names = groups.get(cat)
+        if not names:
+            continue
+        out.append(_heading(cat, "-"))
+        out.append(_autosummary("sky130.pcells", names))
+
+    PCELLS_RST.write_text("\n".join(out) + "\n")
+
+
+if __name__ == "__main__":
+    write_components()
+    write_pcells()
+    print(f"wrote {COMPONENTS_RST}")
+    print(f"wrote {PCELLS_RST}")

--- a/docs/write_components_doc.py
+++ b/docs/write_components_doc.py
@@ -134,10 +134,7 @@ def _pcell_category(name: str) -> str:
         return "Capacitors & poly resistors"
     if name in {"via_generator"} or name.startswith("via"):
         return "Vias"
-    if (
-        name.startswith(("bend_", "straight_", "wire_"))
-        or name == "waypoint"
-    ):
+    if name.startswith(("bend_", "straight_", "wire_")) or name == "waypoint":
         return "Routing primitives"
     return "Other"
 
@@ -205,7 +202,9 @@ def _autosummary(module: str, names: Iterable[str]) -> str:
     return "\n".join(body)
 
 
-def _grouped(names: Iterable[str], categorize, order: list[str]) -> dict[str, list[str]]:
+def _grouped(
+    names: Iterable[str], categorize, order: list[str]
+) -> dict[str, list[str]]:
     groups: dict[str, list[str]] = {k: [] for k in order}
     for n in sorted(names):
         if n in SKIP or n.startswith("_"):
@@ -228,9 +227,7 @@ def write_components() -> None:
 
     out: list[str] = []
     out.append(_heading("Cells", "="))
-    out.append(
-        "Fixed (GDS-backed) cells available in the PDK, grouped by function.\n"
-    )
+    out.append("Fixed (GDS-backed) cells available in the PDK, grouped by function.\n")
 
     out.append(_heading("Digital standard cells (sky130_fd_sc_hd)", "-"))
     out.append(
@@ -269,7 +266,7 @@ def write_components() -> None:
         out.append(_heading("Other fixed cells", "-"))
         out.append(_autosummary("sky130.components", leftover))
 
-    COMPONENTS_RST.write_text("\n".join(out) + "\n")
+    COMPONENTS_RST.write_text("\n".join(out).rstrip() + "\n")
 
 
 def write_pcells() -> None:
@@ -278,9 +275,7 @@ def write_pcells() -> None:
 
     out: list[str] = []
     out.append(_heading("PCells", "="))
-    out.append(
-        "Parametric cells available in the PDK, grouped by device family.\n"
-    )
+    out.append("Parametric cells available in the PDK, grouped by device family.\n")
     for cat in PCELL_ORDER:
         names = groups.get(cat)
         if not names:
@@ -288,7 +283,7 @@ def write_pcells() -> None:
         out.append(_heading(cat, "-"))
         out.append(_autosummary("sky130.pcells", names))
 
-    PCELLS_RST.write_text("\n".join(out) + "\n")
+    PCELLS_RST.write_text("\n".join(out).rstrip() + "\n")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- Rewrite `docs/write_components_doc.py` to emit sectioned `components.rst` and `pcells.rst` grouped by function instead of one flat alphabetical list.
- Digital standard cells (`sky130_fd_sc_hd`) split into Inverters, Buffers, Clock, AND/NAND, OR/NOR, XOR/XNOR, Multiplexers, Arithmetic, Complex AOI/OAI, Flip-flops, Latches & delay, Low-power, Physical/fill/tap.
- Analog/RF primitives (`sky130_fd_pr`) split into Capacitors (MIM/VPP), RF NFETs/PFETs/NPN/PNP, ESD and RF test structures.
- PCells split into MOSFETs, Bipolar, Capacitors & poly resistors, Vias, Routing primitives.

## Test plan
- [ ] `python docs/write_components_doc.py` regenerates both files cleanly
- [ ] Sphinx/Jupyter Book build renders the new sections

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Restructure documentation generation for components and parametric cells to group cells by functional category and regenerate sectioned RST outputs.

New Features:
- Generate sectioned components.rst splitting fixed cells into categorized digital standard cells and analog/RF primitives.
- Generate sectioned pcells.rst grouping parametric cells into device-family-based categories.

Enhancements:
- Introduce categorization helpers and ordered groupings for digital, analog/RF, and PCell libraries to improve documentation navigation.
- Refactor docs/write_components_doc.py into a reusable, function-based script with explicit write_components and write_pcells entry points.