### PR TITLE
ci(dependabot): switch to uv ecosystem

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,6 +6,8 @@ updates:
     directory: "/"
     schedule:
       interval: monthly
+    ignore:
+      - dependency-name: "doplaydo/*"
 
   - package-ecosystem: github-actions
     cooldown:


### PR DESCRIPTION
Add uv package-ecosystem with 7-day cooldown and ignore doplaydo/* for both uv and github-actions.

## Summary by Sourcery

CI:
- Update Dependabot configuration to ignore doplaydo/* dependencies in the root package ecosystem.