### PR TITLE
ci: add metric badge workflows and README dashboard

### DIFF
--- a/.github/workflows/model_coverage.yml
+++ b/.github/workflows/model_coverage.yml
@@ -1,0 +1,11 @@
+name: Model Coverage
+on:
+  pull_request:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+jobs:
+  model-coverage:
+    uses: doplaydo/pdk-ci-workflow/.github/workflows/model_coverage.yml@main
+    secrets: inherit

--- a/.github/workflows/model_regression.yml
+++ b/.github/workflows/model_regression.yml
@@ -1,0 +1,11 @@
+name: Model Regression
+on:
+  pull_request:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+jobs:
+  model-regression:
+    uses: doplaydo/pdk-ci-workflow/.github/workflows/model_regression.yml@main
+    secrets: inherit

--- a/.github/workflows/test_coverage.yml
+++ b/.github/workflows/test_coverage.yml
@@ -1,0 +1,11 @@
+name: Test Coverage
+on:
+  pull_request:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+jobs:
+  coverage:
+    uses: doplaydo/pdk-ci-workflow/.github/workflows/test_coverage.yml@main
+    secrets: inherit

--- a/.github/workflows/update_badges.yml
+++ b/.github/workflows/update_badges.yml
@@ -1,0 +1,12 @@
+name: Update Badges
+on:
+  push:
+    branches: [main]
+  schedule:
+    - cron: "0 6 * * 1"
+  workflow_dispatch:
+
+jobs:
+  badges:
+    uses: doplaydo/pdk-ci-workflow/.github/workflows/update_badges.yml@main
+    secrets: inherit

--- a/README.md
+++ b/README.md
@@ -1,5 +1,17 @@
 # sky130 gdsfactory PDK 0.15.2
 
+<!-- BADGES:START -->
+[![Docs](https://github.com/gdsfactory/skywater130/actions/workflows/pages.yml/badge.svg)](https://github.com/gdsfactory/skywater130/actions/workflows/pages.yml)
+[![Tests](https://github.com/gdsfactory/skywater130/actions/workflows/test_code.yml/badge.svg)](https://github.com/gdsfactory/skywater130/actions/workflows/test_code.yml)
+[![DRC](https://github.com/gdsfactory/skywater130/actions/workflows/drc.yml/badge.svg)](https://github.com/gdsfactory/skywater130/actions/workflows/drc.yml)
+[![Model Regression](https://github.com/gdsfactory/skywater130/actions/workflows/model_regression.yml/badge.svg)](https://github.com/gdsfactory/skywater130/actions/workflows/model_regression.yml)
+[![Test Coverage](https://github.com/gdsfactory/skywater130/raw/badges/coverage.svg)](https://github.com/gdsfactory/skywater130/actions/workflows/test_coverage.yml)
+[![Model Coverage](https://github.com/gdsfactory/skywater130/raw/badges/model_coverage.svg)](https://github.com/gdsfactory/skywater130/actions/workflows/model_coverage.yml)
+[![Issues](https://github.com/gdsfactory/skywater130/raw/badges/issues.svg)](https://github.com/gdsfactory/skywater130/issues)
+[![PRs](https://github.com/gdsfactory/skywater130/raw/badges/prs.svg)](https://github.com/gdsfactory/skywater130/pulls)
+<!-- BADGES:END -->
+
+
 [![pypi](https://img.shields.io/pypi/v/sky130)](https://pypi.org/project/sky130/)
 [![black](https://img.shields.io/badge/code%20style-black-000000.svg)](https://github.com/psf/black)
 


### PR DESCRIPTION
## Summary

- Add 4 new CI workflows using centralized reusable workflows from `doplaydo/pdk-ci-workflow`:
  - **model_coverage.yml** — reports fraction of cells with models
  - **model_regression.yml** — runs `make test -k model` to catch regressions
  - **test_coverage.yml** — runs `make test` with `--cov` pinned to package
  - **update_badges.yml** — generates SVG badges (coverage %, models %, issues, PRs)
- Update README with clickable badge dashboard

All logic is centralized — each workflow file is a thin caller (~10 lines).

## Test plan

- [ ] Verify all new workflows pass
- [ ] Check badges render in README after first `update_badges` run

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Add CI workflows for model and test coverage, regression checks, and automated badge updates, and expose their status via a badge dashboard in the README.

New Features:
- Introduce CI workflow to compute and publish model coverage metrics.
- Introduce CI workflow to run model regression tests on pushes and pull requests.
- Introduce CI workflow to measure and publish test coverage.
- Introduce CI workflow to periodically generate and update SVG badges for coverage, model coverage, open issues, and pull requests.
- Add a README badge dashboard linking to key CI workflows and repository health metrics.