### PR TITLE
fix: use numeric DRC badge from badges branch

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 <!-- BADGES:START -->
 [![Docs](https://github.com/gdsfactory/skywater130/actions/workflows/pages.yml/badge.svg)](https://github.com/gdsfactory/skywater130/actions/workflows/pages.yml)
 [![Tests](https://github.com/gdsfactory/skywater130/actions/workflows/test_code.yml/badge.svg)](https://github.com/gdsfactory/skywater130/actions/workflows/test_code.yml)
-[![DRC](https://github.com/gdsfactory/skywater130/actions/workflows/drc.yml/badge.svg)](https://github.com/gdsfactory/skywater130/actions/workflows/drc.yml)
+[![DRC](https://github.com/gdsfactory/skywater130/raw/badges/drc.svg)](https://github.com/gdsfactory/skywater130/actions/workflows/drc.yml)
 [![Model Regression](https://github.com/gdsfactory/skywater130/actions/workflows/model_regression.yml/badge.svg)](https://github.com/gdsfactory/skywater130/actions/workflows/model_regression.yml)
 [![Test Coverage](https://github.com/gdsfactory/skywater130/raw/badges/coverage.svg)](https://github.com/gdsfactory/skywater130/actions/workflows/test_coverage.yml)
 [![Model Coverage](https://github.com/gdsfactory/skywater130/raw/badges/model_coverage.svg)](https://github.com/gdsfactory/skywater130/actions/workflows/model_coverage.yml)


### PR DESCRIPTION
## Summary

- Update DRC badge in README to use the numeric SVG from the `badges` branch instead of the GitHub Actions pass/fail badge
- The DRC workflow now pushes `drc.svg` (with error count) to the `badges` branch (via doplaydo/pdk-ci-workflow#75)

## Test plan

- [ ] Verify DRC badge renders with error count after next DRC run

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Documentation:
- Switch the README DRC badge to reference the numeric drc.svg asset from the badges branch instead of the GitHub Actions workflow badge.