### PR TITLE
add type tags to all @cell components

### DIFF
--- a/sky130/nmos.py
+++ b/sky130/nmos.py
@@ -3,7 +3,7 @@ import numpy as np
 from gdsfactory.typings import Float2, LayerSpec
 
 
-@gf.cell
+@gf.cell(tags={"type": "nmos"})
 def nmos(
     diffusion_layer: LayerSpec = (65, 20),
     poly_layer: LayerSpec = (66, 22),

--- a/sky130/nmos.py
+++ b/sky130/nmos.py
@@ -3,7 +3,7 @@ import numpy as np
 from gdsfactory.typings import Float2, LayerSpec
 
 
-@gf.cell(tags={"type": "nmos"})
+@gf.cell(tags=["nmos"])
 def nmos(
     diffusion_layer: LayerSpec = (65, 20),
     poly_layer: LayerSpec = (66, 22),

--- a/sky130/pcells/mimcap_1.py
+++ b/sky130/pcells/mimcap_1.py
@@ -4,7 +4,7 @@ import gdsfactory as gf
 from gdsfactory.typings import Float2, LayerSpec
 
 
-@gf.cell
+@gf.cell(tags={"type": "mimcap_1"})
 def mimcap_1(
     m3_layer: LayerSpec = (70, 20),
     via3_size: Float2 = (0.2, 0.2),

--- a/sky130/pcells/mimcap_1.py
+++ b/sky130/pcells/mimcap_1.py
@@ -4,7 +4,7 @@ import gdsfactory as gf
 from gdsfactory.typings import Float2, LayerSpec
 
 
-@gf.cell(tags={"type": "mimcap_1"})
+@gf.cell(tags=["mimcap_1"])
 def mimcap_1(
     m3_layer: LayerSpec = (70, 20),
     via3_size: Float2 = (0.2, 0.2),

--- a/sky130/pcells/mimcap_2.py
+++ b/sky130/pcells/mimcap_2.py
@@ -4,7 +4,7 @@ import gdsfactory as gf
 from gdsfactory.typings import Float2, LayerSpec
 
 
-@gf.cell
+@gf.cell(tags={"type": "mimcap_2"})
 def mimcap_2(
     m4_layer: LayerSpec = (71, 20),
     via4_size: Float2 = (0.8, 0.8),

--- a/sky130/pcells/mimcap_2.py
+++ b/sky130/pcells/mimcap_2.py
@@ -4,7 +4,7 @@ import gdsfactory as gf
 from gdsfactory.typings import Float2, LayerSpec
 
 
-@gf.cell(tags={"type": "mimcap_2"})
+@gf.cell(tags=["mimcap_2"])
 def mimcap_2(
     m4_layer: LayerSpec = (71, 20),
     via4_size: Float2 = (0.8, 0.8),

--- a/sky130/pcells/nmos.py
+++ b/sky130/pcells/nmos.py
@@ -4,7 +4,7 @@ import gdsfactory as gf
 from gdsfactory.typings import Float2, LayerSpec
 
 
-@gf.cell(tags={"type": "nmos"})
+@gf.cell(tags=["nmos"])
 def nmos(
     diffusion_layer: LayerSpec = (65, 20),
     poly_layer: LayerSpec = (66, 20),

--- a/sky130/pcells/nmos.py
+++ b/sky130/pcells/nmos.py
@@ -4,7 +4,7 @@ import gdsfactory as gf
 from gdsfactory.typings import Float2, LayerSpec
 
 
-@gf.cell
+@gf.cell(tags={"type": "nmos"})
 def nmos(
     diffusion_layer: LayerSpec = (65, 20),
     poly_layer: LayerSpec = (66, 20),

--- a/sky130/pcells/nmos_5v.py
+++ b/sky130/pcells/nmos_5v.py
@@ -4,7 +4,7 @@ import gdsfactory as gf
 from gdsfactory.typings import Float2, LayerSpec
 
 
-@gf.cell
+@gf.cell(tags={"type": "nmos_5v"})
 def nmos_5v(
     instance_name: str = "",
     diffusion_layer: LayerSpec = (65, 20),

--- a/sky130/pcells/nmos_5v.py
+++ b/sky130/pcells/nmos_5v.py
@@ -4,7 +4,7 @@ import gdsfactory as gf
 from gdsfactory.typings import Float2, LayerSpec
 
 
-@gf.cell(tags={"type": "nmos_5v"})
+@gf.cell(tags=["nmos_5v"])
 def nmos_5v(
     instance_name: str = "",
     diffusion_layer: LayerSpec = (65, 20),

--- a/sky130/pcells/npn_W1L1.py
+++ b/sky130/pcells/npn_W1L1.py
@@ -4,7 +4,7 @@ import gdsfactory as gf
 from gdsfactory.typings import Float2, LayerSpec
 
 
-@gf.cell(tags={"type": "npn_W1L1"})
+@gf.cell(tags=["npn_W1L1"])
 def npn_W1L1(
     E_width: float = 1,
     E_length: float = 1,

--- a/sky130/pcells/npn_W1L1.py
+++ b/sky130/pcells/npn_W1L1.py
@@ -4,7 +4,7 @@ import gdsfactory as gf
 from gdsfactory.typings import Float2, LayerSpec
 
 
-@gf.cell
+@gf.cell(tags={"type": "npn_W1L1"})
 def npn_W1L1(
     E_width: float = 1,
     E_length: float = 1,

--- a/sky130/pcells/npn_W1L2.py
+++ b/sky130/pcells/npn_W1L2.py
@@ -4,7 +4,7 @@ import gdsfactory as gf
 from gdsfactory.typings import Float2, LayerSpec
 
 
-@gf.cell
+@gf.cell(tags={"type": "npn_W1L2"})
 def npn_W1L2(
     E_width: float = 1,
     E_length: float = 2,

--- a/sky130/pcells/npn_W1L2.py
+++ b/sky130/pcells/npn_W1L2.py
@@ -4,7 +4,7 @@ import gdsfactory as gf
 from gdsfactory.typings import Float2, LayerSpec
 
 
-@gf.cell(tags={"type": "npn_W1L2"})
+@gf.cell(tags=["npn_W1L2"])
 def npn_W1L2(
     E_width: float = 1,
     E_length: float = 2,

--- a/sky130/pcells/p_n_poly.py
+++ b/sky130/pcells/p_n_poly.py
@@ -4,7 +4,7 @@ import gdsfactory as gf
 from gdsfactory.typings import Float2, LayerSpec
 
 
-@gf.cell(tags={"type": "p_n_poly"})
+@gf.cell(tags=["p_n_poly"])
 def p_n_poly(
     p_poly_width: float = 0.35,
     p_poly_length: float = 0.5,

--- a/sky130/pcells/p_n_poly.py
+++ b/sky130/pcells/p_n_poly.py
@@ -4,7 +4,7 @@ import gdsfactory as gf
 from gdsfactory.typings import Float2, LayerSpec
 
 
-@gf.cell
+@gf.cell(tags={"type": "p_n_poly"})
 def p_n_poly(
     p_poly_width: float = 0.35,
     p_poly_length: float = 0.5,

--- a/sky130/pcells/p_p_poly.py
+++ b/sky130/pcells/p_p_poly.py
@@ -4,7 +4,7 @@ import gdsfactory as gf
 from gdsfactory.typings import Float2, LayerSpec
 
 
-@gf.cell(tags={"type": "p_p_poly"})
+@gf.cell(tags=["p_p_poly"])
 def p_p_poly(
     p_poly_width: float = 0.35,
     p_poly_length: float = 0.5,

--- a/sky130/pcells/p_p_poly.py
+++ b/sky130/pcells/p_p_poly.py
@@ -4,7 +4,7 @@ import gdsfactory as gf
 from gdsfactory.typings import Float2, LayerSpec
 
 
-@gf.cell
+@gf.cell(tags={"type": "p_p_poly"})
 def p_p_poly(
     p_poly_width: float = 0.35,
     p_poly_length: float = 0.5,

--- a/sky130/pcells/pmos.py
+++ b/sky130/pcells/pmos.py
@@ -4,7 +4,7 @@ import gdsfactory as gf
 from gdsfactory.typings import Float2, LayerSpec
 
 
-@gf.cell
+@gf.cell(tags={"type": "pmos"})
 def pmos(
     diffusion_layer: LayerSpec = (65, 20),
     poly_layer: LayerSpec = (66, 20),

--- a/sky130/pcells/pmos.py
+++ b/sky130/pcells/pmos.py
@@ -4,7 +4,7 @@ import gdsfactory as gf
 from gdsfactory.typings import Float2, LayerSpec
 
 
-@gf.cell(tags={"type": "pmos"})
+@gf.cell(tags=["pmos"])
 def pmos(
     diffusion_layer: LayerSpec = (65, 20),
     poly_layer: LayerSpec = (66, 20),

--- a/sky130/pcells/pmos_5v.py
+++ b/sky130/pcells/pmos_5v.py
@@ -4,7 +4,7 @@ import gdsfactory as gf
 from gdsfactory.typings import Float2, LayerSpec
 
 
-@gf.cell(tags={"type": "pmos_5v"})
+@gf.cell(tags=["pmos_5v"])
 def pmos_5v(
     instance_name: str = "",
     diffusion_layer: LayerSpec = (65, 20),

--- a/sky130/pcells/pmos_5v.py
+++ b/sky130/pcells/pmos_5v.py
@@ -4,7 +4,7 @@ import gdsfactory as gf
 from gdsfactory.typings import Float2, LayerSpec
 
 
-@gf.cell
+@gf.cell(tags={"type": "pmos_5v"})
 def pmos_5v(
     instance_name: str = "",
     diffusion_layer: LayerSpec = (65, 20),

--- a/sky130/pcells/pnp.py
+++ b/sky130/pcells/pnp.py
@@ -4,7 +4,7 @@ import gdsfactory as gf
 from gdsfactory.typings import Float2, LayerSpec
 
 
-@gf.cell(tags={"type": "pnp"})
+@gf.cell(tags=["pnp"])
 def pnp(
     E_width: float = 0.68,
     E_length: float = 0.68,

--- a/sky130/pcells/pnp.py
+++ b/sky130/pcells/pnp.py
@@ -4,7 +4,7 @@ import gdsfactory as gf
 from gdsfactory.typings import Float2, LayerSpec
 
 
-@gf.cell
+@gf.cell(tags={"type": "pnp"})
 def pnp(
     E_width: float = 0.68,
     E_length: float = 0.68,

--- a/sky130/pcells/via_generator.py
+++ b/sky130/pcells/via_generator.py
@@ -4,7 +4,7 @@ import gdsfactory as gf
 from gdsfactory.typings import Float2, LayerSpec
 
 
-@gf.cell
+@gf.cell(tags={"type": "via_generator"})
 def via_generator(
     width: float = 1,
     length: float = 1,

--- a/sky130/pcells/via_generator.py
+++ b/sky130/pcells/via_generator.py
@@ -4,7 +4,7 @@ import gdsfactory as gf
 from gdsfactory.typings import Float2, LayerSpec
 
 
-@gf.cell(tags={"type": "via_generator"})
+@gf.cell(tags=["via_generator"])
 def via_generator(
     width: float = 1,
     length: float = 1,

--- a/sky130/pcells/vias.py
+++ b/sky130/pcells/vias.py
@@ -3,7 +3,7 @@ import gdsfactory as gf
 from sky130.pcells.via_generator import via_generator
 
 
-@gf.cell
+@gf.cell(tags={"type": "vias"})
 def via_m1_m2(
     width: float = 0.5,
     length: float = 0.5,

--- a/sky130/pcells/vias.py
+++ b/sky130/pcells/vias.py
@@ -3,7 +3,7 @@ import gdsfactory as gf
 from sky130.pcells.via_generator import via_generator
 
 
-@gf.cell(tags={"type": "vias"})
+@gf.cell(tags=["vias"])
 def via_m1_m2(
     width: float = 0.5,
     length: float = 0.5,

--- a/sky130/pcells/waveguides.py
+++ b/sky130/pcells/waveguides.py
@@ -5,7 +5,7 @@ from gdsfactory.cross_section import port_names_electrical, port_types_electrica
 from gdsfactory.typings import CrossSectionSpec, LayerSpec, Size
 
 
-@gf.cell(tags={"type": "waveguides"})
+@gf.cell(tags=["waveguides"])
 def wire_corner(
     cross_section: CrossSectionSpec = "metal2",
     width: float | None = None,
@@ -27,7 +27,7 @@ def wire_corner(
     )
 
 
-@gf.cell(tags={"type": "waveguides"})
+@gf.cell(tags=["waveguides"])
 def wire_corner45(
     cross_section: CrossSectionSpec = "metal2",
     radius: float = 10,
@@ -58,7 +58,7 @@ def wire_corner45(
 ####################
 
 
-@gf.cell(tags={"type": "waveguides"})
+@gf.cell(tags=["waveguides"])
 def straight_metal1(
     length: float = 10,
     cross_section: CrossSectionSpec = "metal1",
@@ -76,7 +76,7 @@ def straight_metal1(
     )
 
 
-@gf.cell(tags={"type": "waveguides"})
+@gf.cell(tags=["waveguides"])
 def straight_metal2(
     length: float = 10,
     cross_section: CrossSectionSpec = "metal2",
@@ -94,7 +94,7 @@ def straight_metal2(
     )
 
 
-@gf.cell(tags={"type": "waveguides"})
+@gf.cell(tags=["waveguides"])
 def bend_metal1(
     radius: float | None = None,
     angle: float = 90,
@@ -119,7 +119,7 @@ def bend_metal1(
     )
 
 
-@gf.cell(tags={"type": "waveguides"})
+@gf.cell(tags=["waveguides"])
 def bend_metal2(
     radius: float | None = None,
     angle: float = 90,
@@ -144,7 +144,7 @@ def bend_metal2(
     )
 
 
-@gf.cell(tags={"type": "waveguides"})
+@gf.cell(tags=["waveguides"])
 def bend_s_metal1(
     size: Size = (11, 1.8),
     cross_section: CrossSectionSpec = "metal1",
@@ -169,7 +169,7 @@ def bend_s_metal1(
     )
 
 
-@gf.cell(tags={"type": "waveguides"})
+@gf.cell(tags=["waveguides"])
 def bend_s_metal2(
     size: Size = (11, 1.8),
     cross_section: CrossSectionSpec = "metal2",

--- a/sky130/pcells/waveguides.py
+++ b/sky130/pcells/waveguides.py
@@ -5,7 +5,7 @@ from gdsfactory.cross_section import port_names_electrical, port_types_electrica
 from gdsfactory.typings import CrossSectionSpec, LayerSpec, Size
 
 
-@gf.cell
+@gf.cell(tags={"type": "waveguides"})
 def wire_corner(
     cross_section: CrossSectionSpec = "metal2",
     width: float | None = None,
@@ -27,7 +27,7 @@ def wire_corner(
     )
 
 
-@gf.cell
+@gf.cell(tags={"type": "waveguides"})
 def wire_corner45(
     cross_section: CrossSectionSpec = "metal2",
     radius: float = 10,
@@ -58,7 +58,7 @@ def wire_corner45(
 ####################
 
 
-@gf.cell
+@gf.cell(tags={"type": "waveguides"})
 def straight_metal1(
     length: float = 10,
     cross_section: CrossSectionSpec = "metal1",
@@ -76,7 +76,7 @@ def straight_metal1(
     )
 
 
-@gf.cell
+@gf.cell(tags={"type": "waveguides"})
 def straight_metal2(
     length: float = 10,
     cross_section: CrossSectionSpec = "metal2",
@@ -94,7 +94,7 @@ def straight_metal2(
     )
 
 
-@gf.cell
+@gf.cell(tags={"type": "waveguides"})
 def bend_metal1(
     radius: float | None = None,
     angle: float = 90,
@@ -119,7 +119,7 @@ def bend_metal1(
     )
 
 
-@gf.cell
+@gf.cell(tags={"type": "waveguides"})
 def bend_metal2(
     radius: float | None = None,
     angle: float = 90,
@@ -144,7 +144,7 @@ def bend_metal2(
     )
 
 
-@gf.cell
+@gf.cell(tags={"type": "waveguides"})
 def bend_s_metal1(
     size: Size = (11, 1.8),
     cross_section: CrossSectionSpec = "metal1",
@@ -169,7 +169,7 @@ def bend_s_metal1(
     )
 
 
-@gf.cell
+@gf.cell(tags={"type": "waveguides"})
 def bend_s_metal2(
     size: Size = (11, 1.8),
     cross_section: CrossSectionSpec = "metal2",

--- a/sky130/pcells/waypoint.py
+++ b/sky130/pcells/waypoint.py
@@ -2,7 +2,7 @@ import gdsfactory as gf
 from gdsfactory.typings import LayerSpec
 
 
-@gf.cell
+@gf.cell(tags={"type": "waypoint"})
 def waypoint(
     width: float = 0.2,
     layer: LayerSpec = (235, 4),

--- a/sky130/pcells/waypoint.py
+++ b/sky130/pcells/waypoint.py
@@ -2,7 +2,7 @@ import gdsfactory as gf
 from gdsfactory.typings import LayerSpec
 
 
-@gf.cell(tags={"type": "waypoint"})
+@gf.cell(tags=["waypoint"])
 def waypoint(
     width: float = 0.2,
     layer: LayerSpec = (235, 4),


### PR DESCRIPTION
## Summary
- Adds `tags={"type": "<filename>"}` to all `@gf.cell` and `@gf.cell_with_module_name` decorators
- Type is derived from the source filename (e.g., `waveguides.py` → `"waveguides"`, `couplers.py` → `"couplers"`)
- Enables filtering and categorization of components by type

Mirrors the change in gdsfactory: https://github.com/gdsfactory/gdsfactory/commit/4c216c5ef

## Test plan
- [ ] Verify all cells still instantiate correctly via `make test`
- [ ] Check that tags appear in cell metadata

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

New Features:
- Annotate all Sky130 @gf.cell components with a "type" tag derived from the defining module name for downstream filtering and categorization.