### PR TITLE
Sync .github templates with upstream pdk-ci-workflow

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,6 +8,7 @@ updates:
       interval: monthly
     ignore:
       - dependency-name: "doplaydo/*"
+      - dependency-name: "jupyter-book"
 
   - package-ecosystem: github-actions
     cooldown:

--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -1,29 +1,26 @@
 name-template: 'v$RESOLVED_VERSION'
 tag-template: 'v$RESOLVED_VERSION'
-change-template: '- $TITLE [#$NUMBER](https://github.com/gdsfactory/skywater130/pull/$NUMBER)'
+change-template: '- $TITLE (#$NUMBER)'
+change-title-escapes: '\<*_&'
 template: |
   # What's Changed
 
   $CHANGES
-
-  **Full Changelog**: https://github.com/$OWNER/$REPOSITORY/compare/$PREVIOUS_TAG...v$RESOLVED_VERSION
-
 categories:
   - title: 'Breaking'
     label: 'breaking'
   - title: 'New'
     labels:
-    - 'feature'
-    - 'enhancement'
+      - 'feature'
+      - 'enhancement'
   - title: 'Bug Fixes'
     label: 'bug'
   - title: 'Maintenance'
     labels:
-    - 'maintenance'
-    - 'github_actions'
+      - 'maintenance'
+      - 'github_actions'
   - title: 'Documentation'
     label: 'documentation'
-  - title: 'Other changes'
   - title: 'Dependency Updates'
     label: 'dependencies'
     collapse-after: 5

--- a/.github/workflows/claude-pr-review.yml
+++ b/.github/workflows/claude-pr-review.yml
@@ -1,55 +1,11 @@
 name: Claude PR Review
-
 on:
   pull_request:
     types: [opened, synchronize, reopened]
   issue_comment:
     types: [created]
 
-permissions:
-  contents: read
-  pull-requests: write
-  issues: write
-  id-token: write
-
 jobs:
-  claude-review:
-    # Run on PR events, or on issue comments that mention @claude
-    if: |
-      github.event_name == 'pull_request' ||
-      (github.event_name == 'issue_comment' &&
-       github.event.issue.pull_request &&
-       contains(github.event.comment.body, '@claude'))
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-
-      - name: Run Claude Code Review
-        uses: anthropics/claude-code-action@beta
-        with:
-          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
-          trigger_phrase: "@claude"
-          model: "claude-sonnet-4-20250514"
-          timeout_minutes: 30
-          allowed_tools: |
-            Read
-            Glob
-            Grep
-            WebFetch
-            WebSearch
-          custom_instructions: |
-            You are a code reviewer for a GDSFactory PDK (Process Design Kit) repository.
-            This repository contains photonic IC design components and models.
-
-            When reviewing PRs, focus on:
-            1. Code quality and adherence to Python best practices
-            2. Proper use of type hints
-            3. Notebook quality and documentation
-            4. Potential bugs or issues
-            5. Pre-commit hook compliance (ruff formatting, pyright type checking)
-
-            Be constructive and helpful in your feedback. Suggest improvements where appropriate.
-            Reference the AGENTS.md file for AI agent best practices in this repository.
+  review:
+    uses: doplaydo/pdk-ci-workflow/.github/workflows/claude-pr-review.yml@main
+    secrets: inherit

--- a/.github/workflows/issue.yml
+++ b/.github/workflows/issue.yml
@@ -1,5 +1,4 @@
 name: Auto-label PDK issues
-
 on:
   issues:
     types:
@@ -20,13 +19,5 @@ on:
       - demilestoned
 
 jobs:
-  add-label:
-    runs-on: ubuntu-latest
-    permissions:
-      issues: write
-    steps:
-      - name: Add label
-        run: gh issue edit ${{ github.event.issue.number }} --add-label "pdk"
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          GH_REPO: ${{ github.repository }}
+  label:
+    uses: doplaydo/pdk-ci-workflow/.github/workflows/issue.yml@main

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -1,39 +1,11 @@
-name: build docs
-
+name: Build docs
 on:
   pull_request:
   push:
-    branches:
-      - main
+    branches: [main]
   workflow_dispatch:
 
 jobs:
-  build-docs:
-    runs-on: ubuntu-latest
-    name: Sphinx docs to gh-pages
-    steps:
-      - uses: actions/checkout@v6
-      - uses: astral-sh/setup-uv@v7
-      - name: Installing the library
-        run: uv sync --all-extras
-      - run: make modules ngspice docs
-      - name: Upload artifact
-        uses: actions/upload-pages-artifact@v4
-        with:
-          path: "./docs/_build/html/"
-  deploy-docs:
-    needs: build-docs
-    if: ${{ github.ref == 'refs/heads/main' }}
-    permissions:
-      pages: write
-      id-token: write
-
-    environment:
-      name: github-pages
-      url: ${{ steps.deployment.outputs.page_url }}
-
-    runs-on: ubuntu-latest
-    steps:
-      - name: Deploy to GitHub Pages
-        id: deployment
-        uses: actions/deploy-pages@v5
+  docs:
+    uses: doplaydo/pdk-ci-workflow/.github/workflows/pages.yml@main
+    secrets: inherit

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -1,18 +1,10 @@
 name: Release Drafter
 on:
   push:
-    branches:
-      - main
-permissions:
-  contents: read
+    branches: [main]
+  workflow_dispatch:
+
 jobs:
-  update_release_draft:
-    permissions:
-      contents: write
-      pull-requests: write
-    runs-on: ubuntu-latest
-    steps:
-      # Drafts your next Release notes as Pull Requests are merged into "master"
-      - uses: release-drafter/release-drafter@v7
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+  draft:
+    uses: doplaydo/pdk-ci-workflow/.github/workflows/release-drafter.yml@main
+    secrets: inherit

--- a/.github/workflows/test_code.yml
+++ b/.github/workflows/test_code.yml
@@ -1,36 +1,10 @@
 name: Test code
-
 on:
   pull_request:
   push:
-    branches:
-      - main
+    branches: [main]
 
 jobs:
-  pre-commit:
-    runs-on: ubuntu-latest
-    steps:
-    - uses: actions/checkout@v6
-    - uses: actions/setup-python@v6
-    - name: Download pre-commit config
-      run: curl -sf https://raw.githubusercontent.com/doplaydo/pdk-ci-workflow/main/templates/.pre-commit-config.yaml -o .pre-commit-config.yaml
-    - uses: pre-commit/action@v3.0.1
-
   test:
-    runs-on: ${{ matrix.os }}
-    strategy:
-      max-parallel: 12
-      matrix:
-        python-version: ["3.12"]
-        os: [ubuntu-latest]
-    steps:
-      - uses: actions/checkout@v6
-        with:
-          submodules: "recursive"
-      - uses: astral-sh/setup-uv@v7
-        with:
-          python-version: ${{ matrix.python-version }}
-      - name: Install Dependencies
-        run: uv sync --all-extras
-      - name: Run Tests
-        run: make modules test
+    uses: doplaydo/pdk-ci-workflow/.github/workflows/test_code.yml@main
+    secrets: inherit


### PR DESCRIPTION
Syncs workflow templates and config files with the canonical versions from doplaydo/pdk-ci-workflow.

Also fixes CODEOWNERS trailing newline for pre-commit compliance.

## Summary by Sourcery

Sync GitHub workflows and release-drafter configuration with the shared doplaydo/pdk-ci-workflow templates while adjusting dependency update rules.

Enhancements:
- Replace local Claude review, docs build, test, release-drafter, and issue labeling workflows with reusable workflows from doplaydo/pdk-ci-workflow to centralize CI logic.
- Simplify release-drafter configuration, including a more generic change template and refined category labels.

Build:
- Update GitHub Actions workflows to use reusable workflows from doplaydo/pdk-ci-workflow for PR reviews, documentation builds, tests, releases, and issue labeling.
- Align the release-drafter workflow trigger configuration with the shared upstream template.

CI:
- Standardize CI workflows by delegating logic to doplaydo/pdk-ci-workflow reusable workflows and inheriting repository secrets.

Chores:
- Adjust Dependabot configuration to ignore jupyter-book dependency updates.