### PR TITLE
Update doroutes to ~=0.6.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ classifiers = [
   "Operating System :: OS Independent"
 ]
 dependencies = [
-  "doroutes~=0.5.0",
+  "doroutes~=0.6.0",
   "gdsfactoryplus",
   "gdsfactory~=9.40.1",
   "PySpice",


### PR DESCRIPTION
## Summary
- Update `doroutes` dependency from `~=0.5.0` to `~=0.6.0`

## Test plan
- [ ] Verify the project installs correctly with `doroutes~=0.6.0`