### PR TITLE
update gdsfactory~=9.43.0 and gplugins~=2.1.0

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,7 +25,7 @@ ngspice:
 test:
 	uv run pytest -s -n logical
 
-test-force:
+test-force: install
 	uv run pytest -s -n logical --force-regen
 
 cov:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,7 @@ classifiers = [
 dependencies = [
   "doroutes~=0.6.0",
   "gdsfactoryplus",
-  "gdsfactory~=9.40.1",
+  "gdsfactory~=9.43.0",
   "PySpice",
   "python-dotenv>=1.2.1"
 ]


### PR DESCRIPTION
## Summary
- Update `gdsfactory` to `~=9.43.0`
- Update `gplugins` to `~=2.1.0`
- Fix `make test-force` to run `install` first (ensures dev dependencies are available)
- Fix `conftest.py` to auto-accept GDS reference updates when `--force-regen` is passed

## Test plan
- [x] Run `make test-force` locally

## Summary by Sourcery

Update core dependencies and ensure force test target installs requirements first.

Build:
- Bump gdsfactory dependency to ~=9.43.0.

Tests:
- Update make test-force target to depend on install so tests run with required dev dependencies.