### PR TITLE
Add zensical docs support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -57,7 +57,23 @@ build:
 tech:
 	python3 install_tech.py
 
-docs:
-	uv run jb build docs
+nbdocs:
+	rm -rf docs/notebooks/*.md
+	find notebooks -maxdepth 1 -mindepth 1 -name "*.ipynb" | sort | \
+		xargs -P4 -I{} uv run --extra docs jupyter nbconvert \
+			--execute --to markdown --embed-images {} --output-dir docs/notebooks
+	uv run python docs/hooks.py docs/notebooks/*.md
 
-.PHONY: gdsdiff build conda docs modules rm-samples
+docs-pdf: nbdocs
+	cp CHANGELOG.md docs/changelog.md
+	uv run mkdocs build -f mkdocs-pdf.yml
+
+docs: nbdocs
+	cp CHANGELOG.md docs/changelog.md
+	uv run --extra docs zensical build
+
+docs-serve: nbdocs
+	cp CHANGELOG.md docs/changelog.md
+	uv run --extra docs zensical serve -a localhost:8080
+
+.PHONY: drc drc-sample doc docs docs-pdf build

--- a/docs/hooks.py
+++ b/docs/hooks.py
@@ -1,0 +1,54 @@
+# ruff: noqa: INP001
+"""Post-process notebook markdown: convert MyST admonitions to Material style.
+
+Usage: python docs/hooks.py docs/notebooks/*.md
+"""
+
+import re
+import sys
+from pathlib import Path
+
+
+def process(markdown: str) -> str:
+    """Apply all transformations to a markdown string."""
+    return _myst_to_material_admonitions(markdown)
+
+
+def _myst_to_material_admonitions(markdown: str) -> str:
+    r"""Convert MyST ```{type}\n...\n``` to Material !!! type\n\n    ..."""
+
+    def _replace(match: re.Match[str]) -> str:
+        kind = match.group(1)
+        body = match.group(2)
+        lines = body.splitlines()
+        title = ""
+        while lines and not lines[0].strip():
+            lines.pop(0)
+        if lines and (m := re.match(r"^#+ +(.+)", lines[0])):
+            title = m.group(1)
+            lines.pop(0)
+        non_empty = [line for line in lines if line.strip()]
+        min_indent = min(
+            (len(line) - len(line.lstrip()) for line in non_empty), default=0
+        )
+        out = []
+        for line in lines:
+            if line.strip():
+                out.append("    " + line[min_indent:])
+            else:
+                out.append("")
+        header = f'!!! {kind} "{title}"' if title else f"!!! {kind}"
+        return header + "\n\n" + "\n".join(out).rstrip() + "\n"
+
+    return re.sub(
+        r"^```\{(\w+)\}\s*\n(.*?)^```\s*$",
+        _replace,
+        markdown,
+        flags=re.MULTILINE | re.DOTALL,
+    )
+
+
+if __name__ == "__main__":
+    for path in sys.argv[1:]:
+        p = Path(path)
+        p.write_text(process(p.read_text()))

--- a/mkdocs-pdf.yml
+++ b/mkdocs-pdf.yml
@@ -1,0 +1,29 @@
+site_name: skywater130 pdk
+docs_dir: docs
+site_dir: build/pdf
+nav:
+  - Home: index.md
+  - Reference:
+      - Changelog: changelog.md
+  - Tutorial:
+      - Overview: tutorial.md
+      - Technology: tech.md
+      - Intro: notebooks/intro.md
+      - Rc Filter Analysis: notebooks/rc_filter_analysis.md
+plugins:
+  - search
+  - autorefs
+  - mkdocstrings:
+      handlers:
+        python:
+          options:
+            docstring_style: google
+            show_root_toc_entry: false
+            show_source: false
+  - with-pdf:
+      author: GDSFactory
+      cover_subtitle: Photonics Process Design Kit
+      output_path: ../../docs.pdf
+theme:
+  name: material
+  logo: logo.png

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,7 +35,14 @@ dev = [
   "pytest-randomly",
   "pytest-xdist"
 ]
-docs = ["jupytext", "jupyter-book==1.0.4"]
+docs = [
+  "jupyter",
+  "mkdocs-material",
+  "mkdocs-with-pdf",
+  "nbconvert",
+  "mkdocstrings[python]>=0.27.0",
+  "zensical>=0.0.40,<0.1.0"
+]
 
 [tool.codespell]
 ignore-words-list = "ba,donot,fpr,nd,ro,schem,te"

--- a/zensical.toml
+++ b/zensical.toml
@@ -1,0 +1,33 @@
+[project]
+nav = [
+  {"Home" = "index.md"},
+  {"Reference" = [
+    {"Changelog" = "changelog.md"}
+  ]},
+  {"Tutorial" = [
+    {"Overview" = "tutorial.md"},
+    {"Technology" = "tech.md"},
+    {"Intro" = "notebooks/intro.md"},
+    {"Rc Filter Analysis" = "notebooks/rc_filter_analysis.md"}
+  ]}
+]
+site_dir = "docs/_build/html"
+site_name = "skywater130 pdk"
+site_url = "https://gdsfactory.github.io/skywater130"
+
+[project.plugins.autorefs]
+
+[project.plugins.mkdocstrings]
+
+[project.plugins.mkdocstrings.handlers.python]
+
+[project.plugins.mkdocstrings.handlers.python.options]
+docstring_style = "google"
+show_root_toc_entry = false
+show_source = false
+
+[project.plugins.search]
+
+[project.theme]
+logo = "logo.png"
+name = "material"


### PR DESCRIPTION
## Summary
- Switch documentation to zensical (Material theme) with mkdocs-pdf support
- Update Makefile with `docs`, `docs-serve`, and `docs-pdf` targets

## Test plan
- [ ] `make docs` builds HTML documentation
- [ ] `make docs-pdf` generates PDF

## Summary by Sourcery

Switch project documentation to a Zensical/MkDocs Material-based site with PDF export and new notebook processing pipeline.

New Features:
- Introduce Zensical/MkDocs Material configuration for the documentation site, including navigation, theme, and mkdocstrings integration.
- Add MkDocs configuration to generate a PDF version of the documentation with Material theme and project metadata.
- Add a notebook-to-Markdown processing hook to convert MyST-style admonitions to Material-style admonitions for docs.

Enhancements:
- Update Makefile documentation targets to build HTML docs, serve them locally, and generate PDFs using the new Zensical/MkDocs-based workflow.
- Expand the docs dependency group to include MkDocs Material, PDF generation, notebook conversion, and Zensical tooling.