### PR TITLE
Strip hyperlinks from changelog in docs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -65,15 +65,15 @@ nbdocs:
 	uv run python docs/hooks.py docs/notebooks/*.md
 
 docs-pdf: nbdocs
-	cp CHANGELOG.md docs/changelog.md
+	uv run python -c "import re; from pathlib import Path; t=Path('CHANGELOG.md').read_text(); Path('docs/changelog.md').write_text(re.sub(r'\[([^\]]*)\]\([^)]*\)', r'\1', t))"
 	uv run mkdocs build -f mkdocs-pdf.yml
 
 docs: nbdocs
-	cp CHANGELOG.md docs/changelog.md
+	uv run python -c "import re; from pathlib import Path; t=Path('CHANGELOG.md').read_text(); Path('docs/changelog.md').write_text(re.sub(r'\[([^\]]*)\]\([^)]*\)', r'\1', t))"
 	uv run --extra docs zensical build
 
 docs-serve: nbdocs
-	cp CHANGELOG.md docs/changelog.md
+	uv run python -c "import re; from pathlib import Path; t=Path('CHANGELOG.md').read_text(); Path('docs/changelog.md').write_text(re.sub(r'\[([^\]]*)\]\([^)]*\)', r'\1', t))"
 	uv run --extra docs zensical serve -a localhost:8080
 
 .PHONY: drc drc-sample doc docs docs-pdf build


### PR DESCRIPTION
## Summary
- Replace `cp CHANGELOG.md docs/changelog.md` with a Python one-liner that strips `[text](url)` → `text`
- Matches the CI "Sync changelog" step in pdk-ci-workflow
- Fixes broken/stale hyperlinks in rendered docs changelog

## Test plan
- [ ] Verify `make docs` produces `docs/changelog.md` without hyperlinks

## Summary by Sourcery

Build:
- Replace direct copying of CHANGELOG.md with a Python command that removes Markdown hyperlinks when generating docs changelog.