### PR TITLE
fix: remove empty stub pages and tableofcontents directives

### DIFF
--- a/docs/notebooks.md
+++ b/docs/notebooks.md
@@ -1,1 +1,0 @@
-# Notebooks

--- a/docs/tutorial.md
+++ b/docs/tutorial.md
@@ -1,1 +1,0 @@
-# Tutorial


### PR DESCRIPTION
## Summary

- Delete `.md` stub files (empty, header-only, or tableofcontents-only)
- Update `_toc.yml` to remove references to deleted files

## Test plan
- [ ] Verify docs build succeeds

## Summary by Sourcery

Clean up documentation by removing unused tutorial stub pages and simplifying the Jupyter Book table of contents.

Documentation:
- Remove obsolete tutorial and notebooks stub pages from the documentation.
- Flatten and update the Jupyter Book table of contents structure to exclude the removed pages.