### PR TITLE
feat: add Makefile target to test sample projects with gfp test

### DIFF
--- a/.github/workflows/sample-projects.yml
+++ b/.github/workflows/sample-projects.yml
@@ -1,0 +1,14 @@
+name: Test Sample Projects
+on:
+  workflow_dispatch:
+  push:
+    branches: [main]
+    paths: ['*--sample-projects/**']
+  pull_request:
+    paths: ['*--sample-projects/**']
+
+jobs:
+  test-sample-projects:
+    uses: doplaydo/pdk-ci-workflow/.github/workflows/test-sample-projects.yml@main
+    secrets:
+      GFP_API_KEY: ${{ secrets.GFP_API_KEY }}

--- a/Makefile
+++ b/Makefile
@@ -28,6 +28,9 @@ test:
 test-force: install
 	uv run pytest -s -n logical --force-regen
 
+test-gfp-projects:
+	cd sky130--sample-projects/sky130--public--project && uv run --directory $(CURDIR) gfp test
+
 cov:
 	uv run pytest --cov=sky130
 


### PR DESCRIPTION
## Summary

- Add `test-gfp-projects` Makefile target that runs `gfp test` inside each sample project
- Ensures all cells in sample projects are tested

**Sample projects tested:**
  - `sky130--sample-projects/sky130--public--project`

**Usage:**
```bash
make test-gfp-projects
```

## Test plan
- [ ] Run `make test-gfp-projects` and verify all tests pass

## Summary by Sourcery

Build:
- Add a test-gfp-projects Makefile target that runs `gfp test` within the sky130 public sample project directory.