### PR TITLE
Replace RST code directives with markdown code blocks

### DIFF
--- a/sky130/tech.py
+++ b/sky130/tech.py
@@ -24,11 +24,11 @@ def xsection(func: Callable[..., CrossSection]) -> Callable[..., CrossSection]:
 
     Ensures that the cross-section name matches the name of the function that generated it when created using default parameters
 
-    .. code-block:: python
-
+    ```python
         @xsection
         def strip(width=TECH.width_strip, radius=TECH.radius_strip):
             return gf.cross_section.cross_section(width=width, radius=radius)
+    ```
     """
     default_xs = func()
     _cross_section_default_names[default_xs.name] = func.__name__


### PR DESCRIPTION
## Summary

- Replace `.. code::` and `.. code-block:: python` RST directives with markdown triple-backtick code blocks in docstrings
- ASCII art diagrams and code examples were not rendering correctly with the new docs theme because it expects markdown, not RST

## Test plan

- [ ] Verify docs build correctly
- [ ] Check ASCII art diagrams render properly in the docs

## Summary by Sourcery

Documentation:
- Replace reStructuredText code-block directives in docstrings with Markdown triple-backtick code fences for proper rendering in the docs theme.