### PR TITLE
Bump doroutes dependency to ~=1.0.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ classifiers = [
   "Operating System :: OS Independent"
 ]
 dependencies = [
-  "doroutes~=0.6.0",
+  "doroutes~=1.0.0",
   "gdsfactoryplus",
   "gdsfactory~=9.43.0",
   "PySpice",


### PR DESCRIPTION
## Summary
- Updates doroutes dependency from `~=0.6.0` to `~=1.0.0`
- Closes #197

## Test plan
- [ ] Verify DoRoutes 1.0.0 is published
- [ ] Run PDK tests after updating