### PR TITLE
Add CLAUDE.md symlink to AGENTS.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,9 @@
+# Agents
+
+## Code Standards
+
+### Required Before Each Commit
+
+- **ALWAYS** run `pre-commit run --all-files` before committing any changes
+- Pre-commit hooks will automatically run code formatting (ruff), linting, and other quality checks
+- All pre-commit hooks must pass before any changes can be committed


### PR DESCRIPTION
## Summary

- Add `CLAUDE.md` as a symlink pointing to `AGENTS.md`
- This allows Claude Code to pick up the same agent instructions that other AI coding tools use via `AGENTS.md`

## Test plan

- [x] Pre-commit passes
- [ ] CI passes

## Summary by Sourcery

Documentation:
- Add CLAUDE.md as a symlink reference to AGENTS.md to reuse the existing agent instructions for Claude Code.