### PR TITLE
Add sample_projects to tbump config

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -137,6 +137,10 @@ src = "sky130/klayout/pymacros/set_menus.lym"
 [[tool.tbump.file]]
 src = "sky130/klayout/grain.xml"
 
+[[tool.tbump.file]]
+search = 'sky130~={current_version}'
+src = "sky130--sample-projects/sky130--public--project/pyproject.toml"
+
 [tool.tbump.git]
 message_template = "Bump to {new_version}"
 tag_template = "v{new_version}"


### PR DESCRIPTION
## Summary
- Add missing `[[tool.tbump.file]]` entries for sample_projects to tbump config
- This ensures that when the PDK version is bumped via `tbump`, the dependency versions in sample_projects are also updated

## Test plan
- [ ] Run `tbump --dry-run <next_version>` and verify sample_project files are included in the bump