### PR TITLE
add missing codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @joamatab @ThomasPluck @kevinwguan
+* @joamatab @ThomasPluck @kevinwguan @nikosavola @sheron-lian @thanojo @Alex-l-r @cdaunt


### PR DESCRIPTION
## Summary
- Ensure all required reviewers are listed in CODEOWNERS
- Added missing people from: @joamatab @ThomasPluck @nikosavola @sheron-lian @thanojo @Alex-l-r @cdaunt

## Test plan
- [x] Verify CODEOWNERS file has all required users

## Summary by Sourcery

Chores:
- Add missing users as code owners to keep review responsibilities up to date.