### PR TITLE
Add das-dias as codeowner

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @joamatab @ThomasPluck @kevinwguan @nikosavola @sheron-lian @thanojo @Alex-l-r @cdaunt
+* @joamatab @ThomasPluck @kevinwguan @nikosavola @sheron-lian @thanojo @Alex-l-r @cdaunt @das-dias


### PR DESCRIPTION
## Summary
- Add @das-dias to CODEOWNERS

## Summary by Sourcery

Chores:
- Update CODEOWNERS to include @das-dias as a code owner.