### PR TITLE
ci: sync code-security.yml with upstream template

### DIFF
--- a/.github/workflows/code-security.yml
+++ b/.github/workflows/code-security.yml
@@ -25,5 +25,5 @@ jobs:
     uses: doplaydo/infra/.github/workflows/reuseable-sca.yaml@main
     with:
       scan-type: fs
-      scanners: misconfig,secret
+      scanners: vuln,misconfig,secret
       fail-on-findings: false


### PR DESCRIPTION
## Summary

- Syncs `.github/workflows/code-security.yml` with the upstream `pdk-ci-workflow` template
- Adds `vuln` to the SCA scanners list (`misconfig,secret` → `vuln,misconfig,secret`)
- Fixes the `check-template-drift` pre-commit failure that is making the CI dashboard show red

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

CI:
- Include the vulnerability scanner in the SCA scanners list for the reusable code-security workflow.