### PR TITLE
Update CODEOWNERS: remove departed members

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @joamatab @kevinwguan @nikosavola @sheron-lian @thanojo @Alex-l-r @cdaunt @das-dias
+* @joamatab @kevinwguan @thanojo @Alex-l-r @cdaunt @das-dias

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @joamatab @kevinwguan @thanojo @Alex-l-r @cdaunt @das-dias
+* @joamatab @kevinwguan @thanojo @cdaunt @das-dias

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @joamatab @ThomasPluck @kevinwguan @nikosavola @sheron-lian @thanojo @Alex-l-r @cdaunt @das-dias
+* @joamatab @kevinwguan @nikosavola @sheron-lian @thanojo @Alex-l-r @cdaunt @das-dias


### PR DESCRIPTION
Remove @ThomasPluck, @tvt173, @nikosavola, @sheron-lian, and @Alex-l-r from CODEOWNERS as requested.