### PR TITLE
Add --verbose flag to twine upload

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,7 +29,7 @@ jobs:
           TWINE_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
         run: |
           make modules build
-          twine upload dist/*
+          twine upload --verbose dist/*
   release_environment:
     if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags')
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary
- Adds --verbose flag to twine upload commands in the release workflow for better upload diagnostics.

Closes #215

## Test plan
- [ ] Trigger a release workflow run and verify twine outputs verbose logs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Build:
- Add the --verbose flag to twine upload in the release GitHub Actions workflow for improved diagnostics.