### PR TITLE
fix: correct pre-commit instructions and add tests section to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,22 @@ uv venv --python 3.12
 uv sync --extra docs --extra dev
 ```
 
+## Pre-commit
+
+Pre-commit hooks are centrally maintained in [pdk-ci-workflow](https://github.com/doplaydo/pdk-ci-workflow). `make dev` fetches the canonical config and installs the git hook.
+
+```bash
+make dev
+```
+
+## Tests
+
+Run the test suite:
+
+```bash
+make test
+```
+
 ## Documentation
 
 - [gdsfactory docs](https://gdsfactory.github.io/gdsfactory/)

--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ uv sync --extra docs --extra dev
 
 ## Pre-commit
 
-Pre-commit hooks are centrally maintained in [pdk-ci-workflow](https://github.com/doplaydo/pdk-ci-workflow). `make dev` fetches the canonical config and installs the git hook.
+Pre-commit hooks are centrally maintained in [pdk-ci-workflow-public](https://github.com/doplaydo/pdk-ci-workflow-public). `make dev` fetches the canonical config and installs the git hook.
 
 ```bash
 make dev

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # sky130 gdsfactory PDK 1.0.0
 
+SkyWater's SKY130 is a fully open-source 130nm CMOS process (with Google) — no NDA required, widely used for open-source chip design and education.
+
 <!-- BADGES:START -->
 [![Docs](https://github.com/gdsfactory/skywater130/actions/workflows/pages.yml/badge.svg)](https://github.com/gdsfactory/skywater130/actions/workflows/pages.yml)
 [![Tests](https://github.com/gdsfactory/skywater130/actions/workflows/test_code.yml/badge.svg)](https://github.com/gdsfactory/skywater130/actions/workflows/test_code.yml)


### PR DESCRIPTION
The Makefile's pre-commit setup target is `dev` (fetches the canonical config from pdk-ci-workflow), not `make pre-commit`. This updates the README to match, and adds a missing `## Tests` section documenting `make test`.

Part of doplaydo/pdks#49.

## Summary by Sourcery

Document pre-commit setup and test execution commands in the README.

Documentation:
- Add a Pre-commit section describing centralized hook configuration and the `make dev` setup command.
- Add a Tests section describing how to run the test suite via `make test` in the README.