### PR TITLE
fix: add markdown extensions for PDF tab rendering

### DIFF
--- a/mkdocs-pdf.yml
+++ b/mkdocs-pdf.yml
@@ -9,6 +9,11 @@ nav:
       - Technology: tech.md
       - Intro: intro.md
       - Rc Filter Analysis: rc_filter_analysis.md
+markdown_extensions:
+  - pymdownx.tabbed:
+      alternate_style: true
+  - pymdownx.superfences
+  - admonition
 plugins:
   - search
   - autorefs


### PR DESCRIPTION
## Summary

Add `pymdownx.tabbed`, `pymdownx.superfences`, and `admonition` markdown extensions to `mkdocs-pdf.yml` so content tabs and warning blocks render correctly in the release PDF.

Without these extensions, the PDF shows literal tab syntax and raw admonition markup instead of rendered content.

Same fix as doplaydo/tps45#296.

## Changes

- `mkdocs-pdf.yml`: Add `markdown_extensions` section

## Test plan

- [x] Verify `mkdocs build -f mkdocs-pdf.yml` succeeds

Closes #230

## Summary by Sourcery

Build:
- Add required markdown extensions to mkdocs-pdf.yml for proper rendering of tabs and admonitions in PDF builds.