### PR TITLE
docs: document c and layer on _via_array

### DIFF
--- a/sky130/pcells/capacitors.py
+++ b/sky130/pcells/capacitors.py
@@ -51,6 +51,10 @@ def _via_array(
 
     Parameters
     ----------
+    c : gf.Component
+        Component the vias are added to.
+    layer : LayerSpec
+        Layer the vias are drawn on.
     region_x0, region_y0, region_x1, region_y1 : float
         Bounding box of the region within which vias are placed.
     via_size : float


### PR DESCRIPTION
Closes #240

The shared pre-commit config now runs `pydocstyle --select=D417`, which requires every positional and keyword-only argument to have an entry in the docstring `Args:` / `Parameters` section.

`_via_array` in `sky130/pcells/capacitors.py` documented its geometry arguments but not `c` (the component the vias are added to) or `layer`. Added both to the existing numpy-style `Parameters` block.

Docstrings only; no behavior change.

## Test plan
- [ ] CI pre-commit job passes

---
Requested by @joamatab. Opened from a fork — I do not have push access to this repo. AI-authored: please review the wording of the new argument descriptions before merging.

## Summary by Sourcery

Documentation:
- Document the `c` and `layer` parameters for the `_via_array` helper to satisfy the project’s docstring validation requirements.